### PR TITLE
docs: update readme to reflect this is for Angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# Server-side DOM implementation based on Mozilla's dom.js
+DO NOT USE THIS REPO! It's only intended use is to support Angular's server side rendering in platform-server.
+We will only accept bugfixes that affect SSR within Angular.
 
-[![Build Status][1]][2] [![dependency status][3]][4] [![dev dependency status][5]][6]
+# Angular Server-side DOM implementation based on Mozilla's dom.js
+
+This is a fork of (domino)[https://github.com/fgnass/domino].
 
 As the name might suggest, domino's goal is to provide a <b>DOM in No</b>de.
 


### PR DESCRIPTION
This updates the readme of domino to indicate this is an Angular-use only repository.