### PR TITLE
fix: restore createWindow function

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,4 @@
-declare module "domino" {
+declare module 'domino' {
   function createDOMImplementation(): DOMImplementation;
   function createDocument(html?: string, force?: boolean): Document;
   function createWindow(html?: string, address?: string): Window;

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,7 +67,13 @@ exports.createIncrementalHTMLParser = function() {
         document: function() {
           return parser.document();
         },
-    };
+    };  
+};
+
+exports.createWindow = function(html, address) {
+  var document = exports.createDocument(html);
+  if (address !== undefined) { document._address = address; }
+  return new domino.impl.Window(document);
 };
 
 exports.impl = require('./impl');


### PR DESCRIPTION
This restores a used createWindow function that when missing causes issues with angular/angular tests .