### PR TITLE
fix: update broken import of Window object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 var DOMImplementation = require('./DOMImplementation');
 var HTMLParser = require('./HTMLParser');
 var Window = require('./Window');
+var impl = require('./impl');
 
 exports.createDOMImplementation = function() {
   return new DOMImplementation(null);
@@ -73,7 +74,7 @@ exports.createIncrementalHTMLParser = function() {
 exports.createWindow = function(html, address) {
   var document = exports.createDocument(html);
   if (address !== undefined) { document._address = address; }
-  return new domino.impl.Window(document);
+  return new impl.Window(document);
 };
 
-exports.impl = require('./impl');
+exports.impl = impl;


### PR DESCRIPTION
This updates the path to window so that it doesn't rely on a broken "domino" reference.