### PR TITLE
fix: do not emit known invalid values

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -133,7 +133,7 @@ CSSStyleDeclaration.prototype = Object.create(Object.prototype, {
       value = "" + value;
     }
 
-    if (value === "") {
+    if (value === "" || isQuotedInvalidUnitValue(value)) {
       this.removeProperty(property);
       return;
     }
@@ -595,5 +595,52 @@ function defineStyleProperty(jsname) {
         this.setProperty(cssname, value);
       }
     });
+  }
+}
+
+const REGEXP_VALUE_WITH_QUOTES_UNIT = /^["']([+\-]?[\d\.]+)([a-z]+)["']$/;
+
+/**
+ * This method return true when the value is quoted and has a unit. Example `"1px"`.
+ * In this case the value is invalid and browsers will remove it.
+ *
+ * @param {*} value css property value.
+ * @returns true when the value is invalid as it's quoted.
+ */
+function isQuotedInvalidUnitValue(value) {
+  const match = REGEXP_VALUE_WITH_QUOTES_UNIT.exec(value);
+  if (!match) {
+    return false;
+  }
+
+  switch(match[2].toLowerCase()){
+    case "em":
+    case "rem":
+    case "ex":
+    case "px":
+    case "cm":
+    case "mm":
+    case "in":
+    case "pt":
+    case "pc":
+    case "ch":
+    case "vh":
+    case "vw":
+    case "vmax":
+    case "vmin":
+    case "fr":
+    case "deg":
+    case "rad":
+    case "grad":
+    case "ms":
+    case "s":
+    case "hz":
+    case "khz":
+    case "dpi":
+    case "dpcm":
+    case "%":
+      return true;
+    default:
+      return false;
   }
 }

--- a/test/domino.js
+++ b/test/domino.js
@@ -1461,3 +1461,10 @@ exports.incrementalHTMLParser2 = function() {
     '<html><head></head><body><p>hello<b>foo&amp;</b></p></body></html>'
   );
 };
+
+exports.quotedUnitValues = function() {
+  var document = domino.createDocument('<div></div>');
+  var div = document.querySelector('div');
+  div.style.width = '"0px"';
+  div.outerHTML.should.equal('<div></div>');
+};


### PR DESCRIPTION
This commit adds a fix so that known invalid values are not added. This is so that Domino mimics more the browser behaviour were known invalid values are not added.