### PR TITLE
fix: correct handle `innerText`

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -133,6 +133,7 @@ CSSStyleDeclaration.prototype = Object.create(Object.prototype, {
       value = "" + value;
     }
 
+    value = value.trim();
     if (value === "") {
       this.removeProperty(property);
       return;

--- a/lib/Comment.js
+++ b/lib/Comment.js
@@ -25,6 +25,7 @@ Comment.prototype = Object.create(CharacterData.prototype, {
   nodeName: { value: '#comment' },
   nodeValue: nodeValue,
   textContent: nodeValue,
+  innerText: nodeValue,
   data: {
     get: nodeValue.get,
     set: function(v) {

--- a/lib/DocumentFragment.js
+++ b/lib/DocumentFragment.js
@@ -16,14 +16,17 @@ function DocumentFragment(doc) {
 
 DocumentFragment.prototype = Object.create(ContainerNode.prototype, {
   nodeName: { value: '#document-fragment' },
-  nodeValue: { 
-    get: function() { 
+  nodeValue: {
+    get: function() {
       return null;
     },
     set: function() {}
   },
   // Copy the text content getter/setter from Element
   textContent: Object.getOwnPropertyDescriptor(Element.prototype, 'textContent'),
+
+  // Copy the text content getter/setter from Element
+  innerText: Object.getOwnPropertyDescriptor(Element.prototype, 'innerText'),
 
   querySelector: { value: function(selector) {
     // implement in terms of querySelectorAll

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -93,7 +93,10 @@ Element.prototype = Object.create(ContainerNode.prototype, {
       var strings = [];
       recursiveGetText(this, strings);
       // Strip and collapse whitespace
-      // This doesn't 100% match the browser behavior
+      // This doesn't 100% match the browser behavior,
+      // but should cover most of the cases. This is also similar to
+      // how Angular's renderer used to work: the `textContent` and `innerText`
+      // were almost equivalent from the renderer perspective.
       // See: https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent#differences_from_innertext
       return strings.join('').replace(/[ \t\n\f\r]+/g, ' ').trim();
     },

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -88,6 +88,22 @@ Element.prototype = Object.create(ContainerNode.prototype, {
       }
     }
   },
+  innerText: {
+    get: function() {
+      var strings = [];
+      recursiveGetText(this, strings);
+      // Strip and collapse whitespace
+      // This doesn't 100% match the browser behavior
+      // See: https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent#differences_from_innertext
+      return strings.join('').replace(/[ \t\n\f\r]+/g, ' ').trim();
+    },
+    set: function(newtext) {
+      this.removeChildren();
+      if (newtext !== null && newtext !== undefined && newtext !== '') {
+        this._appendChild(this.ownerDocument.createTextNode(newtext));
+      }
+    }
+  },
   innerHTML: {
     get: function() {
       return this.serialize();
@@ -1037,6 +1053,13 @@ Attr.prototype = Object.create(Object.prototype, {
     set: function(v) { this.value = v; },
   },
   textContent: {
+    get: function() { return this.value; },
+    set: function(v) {
+      if (v === null || v === undefined) { v = ''; }
+      this.value = v;
+    },
+  },
+  innerText: {
     get: function() { return this.value; },
     set: function(v) {
       if (v === null || v === undefined) { v = ''; }

--- a/lib/Node.js
+++ b/lib/Node.js
@@ -94,6 +94,12 @@ Node.prototype = Object.create(EventTarget.prototype, {
     set: function(v) { /* do nothing */ },
   },
 
+  innerText: {
+    // Should override for DocumentFragment/Element/Attr/Text/PI/Comment
+    get: function() { return null; },
+    set: function(v) { /* do nothing */ },
+  },
+
   _countChildrenOfType: { value: function(type) {
     var sum = 0;
     for (var kid = this.firstChild; kid !== null; kid = kid.nextSibling) {

--- a/lib/ProcessingInstruction.js
+++ b/lib/ProcessingInstruction.js
@@ -25,6 +25,7 @@ ProcessingInstruction.prototype = Object.create(CharacterData.prototype, {
   nodeName: { get: function() { return this.target; }},
   nodeValue: nodeValue,
   textContent: nodeValue,
+  innerText: nodeValue,
   data: {
     get: nodeValue.get,
     set: function(v) {

--- a/lib/Text.js
+++ b/lib/Text.js
@@ -34,6 +34,7 @@ Text.prototype = Object.create(CharacterData.prototype, {
   // implement that at the interface level
   nodeValue: nodeValue,
   textContent: nodeValue,
+  innerText: nodeValue,
   data: {
     get: nodeValue.get,
     set: function(v) {

--- a/test/domino.js
+++ b/test/domino.js
@@ -706,6 +706,16 @@ exports.gh70 = function() {
   classAttr.value.should.equal('textContent');
   classAttr.nodeValue.should.equal('textContent');
   classAttr.textContent.should.equal('textContent');
+  classAttr.innerText.should.equal('textContent');
+};
+
+exports.innerText = function() {
+  var document = domino.createDocument('<div>Hello <h1>world!</h1></div>');
+  var div = document.querySelector('div');
+  div.innerText.should.equal('Hello world!'); // getter
+  div.innerText = 'Hi'; // setter
+  div.textContent.should.equal('Hi');
+  div.innerText.should.equal('Hi');
 };
 
 exports.gh71 = function() {

--- a/test/domino.js
+++ b/test/domino.js
@@ -1471,3 +1471,10 @@ exports.incrementalHTMLParser2 = function() {
     '<html><head></head><body><p>hello<b>foo&amp;</b></p></body></html>'
   );
 };
+
+exports.shouldNotEmptyStyle = function() {
+  var document = domino.createDocument('<div></div>');
+  var div = document.querySelector('div');
+  div.style.flex = '    ';
+  div.outerHTML.should.equal('<div></div>');
+};


### PR DESCRIPTION
Prior to this commit `innerText` was not supported.

See: https://github.com/angular/angular/blob/ef149defb98aa9edba05359b27594594fe5b7617/packages/platform-server/src/server_renderer.ts#L187-L190