### PR TITLE
fix: update Domino to support newer attributes

### DIFF
--- a/lib/htmlelts.js
+++ b/lib/htmlelts.js
@@ -50,7 +50,7 @@ function CORS(attr) {
   };
 }
 
-var REFERRER = {
+const REFERRER = {
   type: ["", "no-referrer", "no-referrer-when-downgrade", "same-origin", "origin", "strict-origin", "origin-when-cross-origin", "strict-origin-when-cross-origin", "unsafe-url"],
   missing: '',
 };
@@ -81,7 +81,7 @@ var HTMLElement = exports.HTMLElement = define({
       set: function (v) {
         this._innerHTML = v;
       },
-    },    
+    },
     innerHTML: {
       get: function() {
         return this.serialize();
@@ -156,8 +156,15 @@ var HTMLElement = exports.HTMLElement = define({
     title: String,
     lang: String,
     dir: {type: ["ltr", "rtl", "auto"], missing: ''},
+    draggable: {type: ["true", "false"], treatNullAsEmptyString: true },
+    spellcheck: {type: ["true", "false"], missing: ''},
+    enterKeyHint: {type: ["enter", "done", "go", "next", "previous", "search", "send"], missing: ''},
+    autoCapitalize: {type: ["off", "on", "none", "sentences", "words", "characters"], missing: '' },
+    autoFocus: Boolean,
     accessKey: String,
+    nonce: String,
     hidden: Boolean,
+    translate: {type: ["no", "yes"], missing: '' },
     tabIndex: {type: "long", default: function() {
       if (this.tagName in focusableElements ||
         this.contentEditable)
@@ -354,6 +361,7 @@ define({
     autofocus: Boolean,
     type: { type:["submit", "reset", "button", "menu"], missing: 'submit' },
     formTarget: String,
+    formAction: URL,
     formNoValidate: Boolean,
     formMethod: { type: ["get", "post", "dialog"], invalid: 'get', missing: '' },
     formEnctype: { type: ["application/x-www-form-urlencoded", "multipart/form-data", "text/plain"], invalid: "application/x-www-form-urlencoded", missing: '' },
@@ -507,6 +515,7 @@ define({
     HTMLElement.call(this, doc, localName, prefix);
   },
   attributes: {
+    xmlns: URL,
     // Obsolete
     version: String
   }
@@ -526,10 +535,12 @@ define({
     height: String,
     // XXX: sandbox is a reflected settable token list
     seamless: Boolean,
+    allow: Boolean,
     allowFullscreen: Boolean,
     allowUserMedia: Boolean,
     allowPaymentRequest: Boolean,
     referrerPolicy: REFERRER,
+    loading: { type:['eager','lazy'], treatNullAsEmptyString: true },
     // Obsolete
     align: String,
     scrolling: String,
@@ -553,9 +564,11 @@ define({
     crossOrigin: CORS,
     useMap: String,
     isMap: Boolean,
+    sizes: String,
     height: { type: "unsigned long", default: 0 },
     width: { type: "unsigned long", default: 0 },
     referrerPolicy: REFERRER,
+    loading: { type:['eager','lazy'], missing: '' },
     // Obsolete:
     name: String,
     lowsrc: URL,
@@ -701,6 +714,8 @@ define({
     nonce: String,
     integrity: String,
     referrerPolicy: REFERRER,
+    imageSizes: String,
+    imageSrcset: String,
     // Obsolete
     charset: String,
     rev: String,
@@ -987,8 +1002,10 @@ define({
     src: URL,
     type: String,
     charset: String,
+    referrerPolicy: REFERRER,
     defer: Boolean,
     async: Boolean,
+    nomodule: Boolean,
     crossOrigin: CORS,
     nonce: String,
     integrity: String,
@@ -1015,19 +1032,6 @@ define({
     multiple: Boolean,
     required: Boolean,
     size: {type: "unsigned long", default: 0}
-  }
-});
-
-define({
-  tag: 'source',
-  name: 'HTMLSourceElement',
-  ctor: function HTMLSourceElement(doc, localName, prefix) {
-    HTMLElement.call(this, doc, localName, prefix);
-  },
-  attributes: {
-    src: URL,
-    type: String,
-    media: String
   }
 });
 
@@ -1427,7 +1431,9 @@ define({
     sizes: String,
     media: String,
     src: URL,
-    type: String
+    type: String,
+    width: String,
+    height: String,
   }
 });
 
@@ -1482,11 +1488,10 @@ define({
 
 define({
   tags: [
-    "abbr", "address", "article", "aside", "b", "bdi", "bdo",
-    "cite", "code", "dd", "dfn", "dt", "em", "figcaption", "figure",
-    "footer", "header", "hgroup", "i", "kbd", "main", "mark", "nav", "noscript",
-    "rb", "rp", "rt", "rtc", "ruby", "s", "samp", "section", "small", "strong",
-    "sub", "summary", "sup", "u", "var", "wbr",
+    "abbr", "address", "article", "aside", "b", "bdi", "bdo", "cite", "content", "code",
+    "dd", "dfn", "dt", "em", "figcaption", "figure", "footer", "header", "hgroup", "i", "kbd",
+    "main", "mark", "nav", "noscript", "rb", "rp", "rt", "rtc",
+    "ruby", "s", "samp", "section", "small", "strong", "sub", "summary", "sup", "u", "var", "wbr",
     // Legacy elements
     "acronym", "basefont", "big", "center", "nobr", "noembed", "noframes",
     "plaintext", "strike", "tt"

--- a/test/domino.js
+++ b/test/domino.js
@@ -1485,3 +1485,10 @@ exports.supportModernStyle = function() {
   h1.style.inset = '0px';
   h1.outerHTML.should.equal('<h1 style="color: red !important; inset: 0px;">Hello world</h1>');
 };
+
+exports.supportsNonceAttribute = function() {
+  var document = domino.createDocument('<style>* {color: red}</style>');
+  var h1 = document.querySelector('style');
+  h1.nonce = 'randomhaash';
+  h1.outerHTML.should.equal('<style nonce="randomhaash">* {color: red}</style>');
+};


### PR DESCRIPTION
These have been ported over from https://github.com/angular/angular/blob/main/packages/compiler/src/schema/dom_element_schema_registry.ts and https://developer.mozilla.org/en-US/docs/Web/HTML/Reference

We also removed a incorrect duplicate definition of `HTMLSourceElement` and added a number of additional elements like `content` and `hgroup`.