### PR TITLE
fix: querySelector returns `null` when nothing is found.

### DIFF
--- a/lib/Document.js
+++ b/lib/Document.js
@@ -718,7 +718,7 @@ Document.prototype = Object.create(ContainerNode.prototype, {
   }},
 
   querySelector: { value: function(selector) {
-    return select(selector, this)[0];
+    return select(selector, this)[0] ?? null;
   }},
 
   querySelectorAll: { value: function(selector) {

--- a/lib/Element.js
+++ b/lib/Element.js
@@ -949,7 +949,7 @@ Element.prototype = Object.create(ContainerNode.prototype, {
   }},
 
   querySelector: { value: function(selector) {
-    return select(selector, this)[0];
+    return select(selector, this)[0] ?? null;
   }},
 
   querySelectorAll: { value: function(selector) {

--- a/test/domino.js
+++ b/test/domino.js
@@ -60,6 +60,13 @@ exports.closest = function() {
   (r8 === null).should.be.true();
 };
 
+exports.querySelector = function() {
+  var window = createWindow(html);
+  var d = window.document;
+  var nothing = d.querySelector('.foobar');
+  (nothing === null).should.be.true();
+};
+
 exports.querySelectorAll = function() {
   var window = createWindow(html);
   var d = window.document;
@@ -488,7 +495,7 @@ exports.eqAttr = function() {
   var html = "<div id=a ==x><a=B></A=b></div>";
   var doc = domino.createDocument(html);
   var div = doc.querySelector('#a');
-  (div != null).should.be.true(); // jshint ignore:line
+  (div !== null).should.be.true(); // jshint ignore:line
   div.attributes.length.should.equal(2);
   div.attributes.item(1).name.should.equal('=');
   div.children.length.should.equal(1);


### PR DESCRIPTION
Also: commenting unused test code that prevented from running the unit tests.

Fixes angular/angular#51068