### PR TITLE
fix: escape unsafe patterns in elements, comment nodes and processing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ var domino = require('domino');
 Domino includes test from the [W3C DOM Conformance Suites](http://www.w3.org/DOM/Test/)
 as well as tests from [HTML Working Group](http://www.w3.org/html/wg/wiki/Testing).
 
+When you checkout this repository for the first time, run the following command to also check out code for the mentioned tests:
+
+```
+git submodule update --init --recursive
+```
+
 The tests can be run via `npm test` or directly though the [Mocha](http://mochajs.org/) command line:
 
 ![Screenshot](http://fgnass.github.com/images/domino.png)

--- a/lib/NodeUtils.js
+++ b/lib/NodeUtils.js
@@ -10,7 +10,14 @@ module.exports = {
   // `NodeUtils.serializeOne` to get to the function and reduce pressure
   // on the megamorphic stub cache.
   // See https://github.com/fgnass/domino/pull/142 for more information.
-  serializeOne: serializeOne
+  serializeOne: serializeOne,
+
+  // Export util functions so that we can run extra test for them.
+  // Note: we prefix function names with `ɵ`, similar to what we do
+  // with internal functions in Angular packages.
+  ɵescapeMatchingClosingTag: escapeMatchingClosingTag,
+  ɵescapeClosingCommentTag: escapeClosingCommentTag,
+  ɵescapeProcessingInstructionContent: escapeProcessingInstructionContent
 };
 
 var utils = require('./utils');
@@ -116,6 +123,53 @@ function attrname(a) {
   return a.name;
 }
 
+/**
+ * Escapes matching closing tag in a raw text.
+ *
+ * For example, given `<style>#text(</style><script></script>)</style>`,
+ * the parent tag would by "style" and the raw text is
+ * "</style><script></script>". If we come across a matching closing tag
+ * (in out case `</style>`) - replace `<` with `&lt;` to avoid unexpected
+ * and unsafe behavior after de-serialization.
+ */
+function escapeMatchingClosingTag(rawText, parentTag) {
+  const parentClosingTag = '</' + parentTag;
+  if (!rawText.toLowerCase().includes(parentClosingTag)) {
+    return rawText; // fast path
+  }
+  const result = [...rawText];
+  const matches = rawText.matchAll(new RegExp(parentClosingTag, 'ig'));
+  for (const match of matches) {
+    result[match.index] = '&lt;';
+  }
+  return result.join('');
+}
+
+const CLOSING_COMMENT_REGEXP = /--!?>/;
+
+/**
+ * Escapes closing comment tag in a comment content.
+ *
+ * For example, given `#comment('-->')`, the content of a comment would be
+ * updated to `--&gt;` to avoid unexpected and unsafe behavior after
+ * de-serialization.
+ */
+function escapeClosingCommentTag(rawContent) {
+  if (!CLOSING_COMMENT_REGEXP.test(rawContent)) {
+    return rawContent; // fast path
+  }
+  return rawContent.replace(/(--\!?)>/g, '$1&gt;');
+}
+
+/**
+ * Escapes processing instruction content by replacing `>` with `&gt`.
+ */
+function escapeProcessingInstructionContent(rawContent) {
+  return rawContent.includes('>')
+    ? rawContent.replaceAll('>', '&gt;')
+    : rawContent;
+}
+
 function serializeOne(kid, parent) {
   var s = '';
   switch(kid.nodeType) {
@@ -135,6 +189,11 @@ function serializeOne(kid, parent) {
 
       if (!(html && emptyElements[tagname])) {
         var ss = kid.serialize();
+        // If an element can have raw content, this content may
+        // potentially require escaping to avoid XSS.
+        if (hasRawContent[tagname.toUpperCase()]) {
+          ss = escapeMatchingClosingTag(ss, tagname);
+        }
         if (html && extraNewLine[tagname] && ss.charAt(0)==='\n') s += '\n';
         // Serialize children and add end tag for all others
         s += ss;
@@ -158,10 +217,11 @@ function serializeOne(kid, parent) {
       }
       break;
     case 8: //COMMENT_NODE
-      s += '<!--' + kid.data + '-->';
+      s += '<!--' + escapeClosingCommentTag(kid.data) + '-->';
       break;
     case 7: //PROCESSING_INSTRUCTION_NODE
-      s += '<?' + kid.target + ' ' + kid.data + '?>';
+      const content = escapeProcessingInstructionContent(kid.data);
+      s += '<?' + kid.target + ' ' + content + '?>';
       break;
     case 10: //DOCUMENT_TYPE_NODE
       s += '<!DOCTYPE ' + kid.name;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "jquery": "^3.5.1",
     "mocha": "^6.2.3",
+    "puppeteer": "^21.3.5",
     "should": "^13.2.3"
   }
 }

--- a/test/html5lib-tests.json
+++ b/test/html5lib-tests.json
@@ -4131,8 +4131,8 @@
             ]
           }
         ],
-        "html": "<html><head><script type=\"data\"><!--<script></script></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script type=\"data\"><!--<script></script></script>"
+        "html": "<html><head><script type=\"data\"><!--<script>&lt;/script></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script type=\"data\"><!--<script>&lt;/script></script>"
       }
     },
     {
@@ -4181,8 +4181,8 @@
             ]
           }
         ],
-        "html": "<html><head><script type=\"data\"><!--<script>�</script></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script type=\"data\"><!--<script>�</script></script>"
+        "html": "<html><head><script type=\"data\"><!--<script>�&lt;/script></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script type=\"data\"><!--<script>�&lt;/script></script>"
       }
     },
     {
@@ -4231,8 +4231,8 @@
             ]
           }
         ],
-        "html": "<html><head><script type=\"data\"><!--<script>-�</script></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script type=\"data\"><!--<script>-�</script></script>"
+        "html": "<html><head><script type=\"data\"><!--<script>-�&lt;/script></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script type=\"data\"><!--<script>-�&lt;/script></script>"
       }
     },
     {
@@ -4281,8 +4281,8 @@
             ]
           }
         ],
-        "html": "<html><head><script type=\"data\"><!--<script>--�</script></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script type=\"data\"><!--<script>--�</script></script>"
+        "html": "<html><head><script type=\"data\"><!--<script>--�&lt;/script></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script type=\"data\"><!--<script>--�&lt;/script></script>"
       }
     },
     {
@@ -4330,8 +4330,8 @@
             ]
           }
         ],
-        "html": "<html><head><script type=\"data\"><!--<script>---</script></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script type=\"data\"><!--<script>---</script></script>"
+        "html": "<html><head><script type=\"data\"><!--<script>---&lt;/script></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script type=\"data\"><!--<script>---&lt;/script></script>"
       }
     },
     {
@@ -4379,8 +4379,8 @@
             ]
           }
         ],
-        "html": "<html><head><script type=\"data\"><!--<script></scrip></SCRIPT></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script type=\"data\"><!--<script></scrip></SCRIPT></script>"
+        "html": "<html><head><script type=\"data\"><!--<script></scrip>&lt;/SCRIPT></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script type=\"data\"><!--<script></scrip>&lt;/SCRIPT></script>"
       }
     },
     {
@@ -4428,8 +4428,8 @@
             ]
           }
         ],
-        "html": "<html><head><script type=\"data\"><!--<script></scrip </SCRIPT></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script type=\"data\"><!--<script></scrip </SCRIPT></script>"
+        "html": "<html><head><script type=\"data\"><!--<script></scrip &lt;/SCRIPT></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script type=\"data\"><!--<script></scrip &lt;/SCRIPT></script>"
       }
     },
     {
@@ -4477,8 +4477,8 @@
             ]
           }
         ],
-        "html": "<html><head><script type=\"data\"><!--<script></scrip/</SCRIPT></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script type=\"data\"><!--<script></scrip/</SCRIPT></script>"
+        "html": "<html><head><script type=\"data\"><!--<script></scrip/&lt;/SCRIPT></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script type=\"data\"><!--<script></scrip/&lt;/SCRIPT></script>"
       }
     },
     {
@@ -17725,8 +17725,8 @@
             ]
           }
         ],
-        "html": "<html><head></head><body>FOO<script type=\"text/plain\"></scriptx>BAR</script></body></html>",
-        "noQuirksBodyHtml": "FOO<script type=\"text/plain\"></scriptx>BAR</script>"
+        "html": "<html><head></head><body>FOO<script type=\"text/plain\">&lt;/scriptx>BAR</script></body></html>",
+        "noQuirksBodyHtml": "FOO<script type=\"text/plain\">&lt;/scriptx>BAR</script>"
       }
     },
     {
@@ -18263,8 +18263,8 @@
             ]
           }
         ],
-        "html": "<html><head></head><body>FOO<script type=\"text/plain\">'<!-- <sCrIpt>'</script>BAR</script></body></html>",
-        "noQuirksBodyHtml": "FOO<script type=\"text/plain\">'<!-- <sCrIpt>'</script>BAR</script>"
+        "html": "<html><head></head><body>FOO<script type=\"text/plain\">'<!-- <sCrIpt>'&lt;/script>BAR</script></body></html>",
+        "noQuirksBodyHtml": "FOO<script type=\"text/plain\">'<!-- <sCrIpt>'&lt;/script>BAR</script>"
       }
     },
     {
@@ -18317,8 +18317,8 @@
             ]
           }
         ],
-        "html": "<html><head></head><body>FOO<script type=\"text/plain\">'<!-- <sCrIpt> -'</script>BAR</script></body></html>",
-        "noQuirksBodyHtml": "FOO<script type=\"text/plain\">'<!-- <sCrIpt> -'</script>BAR</script>"
+        "html": "<html><head></head><body>FOO<script type=\"text/plain\">'<!-- <sCrIpt> -'&lt;/script>BAR</script></body></html>",
+        "noQuirksBodyHtml": "FOO<script type=\"text/plain\">'<!-- <sCrIpt> -'&lt;/script>BAR</script>"
       }
     },
     {
@@ -18371,8 +18371,8 @@
             ]
           }
         ],
-        "html": "<html><head></head><body>FOO<script type=\"text/plain\">'<!-- <sCrIpt> --'</script>BAR</script></body></html>",
-        "noQuirksBodyHtml": "FOO<script type=\"text/plain\">'<!-- <sCrIpt> --'</script>BAR</script>"
+        "html": "<html><head></head><body>FOO<script type=\"text/plain\">'<!-- <sCrIpt> --'&lt;/script>BAR</script></body></html>",
+        "noQuirksBodyHtml": "FOO<script type=\"text/plain\">'<!-- <sCrIpt> --'&lt;/script>BAR</script>"
       }
     },
     {
@@ -18474,8 +18474,8 @@
             ]
           }
         ],
-        "html": "<html><head></head><body>FOO<script type=\"text/plain\">'<!-- <sCrIpt> --!>'</script>BAR</script></body></html>",
-        "noQuirksBodyHtml": "FOO<script type=\"text/plain\">'<!-- <sCrIpt> --!>'</script>BAR</script>"
+        "html": "<html><head></head><body>FOO<script type=\"text/plain\">'<!-- <sCrIpt> --!>'&lt;/script>BAR</script></body></html>",
+        "noQuirksBodyHtml": "FOO<script type=\"text/plain\">'<!-- <sCrIpt> --!>'&lt;/script>BAR</script>"
       }
     },
     {
@@ -18528,8 +18528,8 @@
             ]
           }
         ],
-        "html": "<html><head></head><body>FOO<script type=\"text/plain\">'<!-- <sCrIpt> -- >'</script>BAR</script></body></html>",
-        "noQuirksBodyHtml": "FOO<script type=\"text/plain\">'<!-- <sCrIpt> -- >'</script>BAR</script>"
+        "html": "<html><head></head><body>FOO<script type=\"text/plain\">'<!-- <sCrIpt> -- >'&lt;/script>BAR</script></body></html>",
+        "noQuirksBodyHtml": "FOO<script type=\"text/plain\">'<!-- <sCrIpt> -- >'&lt;/script>BAR</script>"
       }
     },
     {
@@ -18582,8 +18582,8 @@
             ]
           }
         ],
-        "html": "<html><head></head><body>FOO<script type=\"text/plain\">'<!-- <sCrIpt '</script>BAR</script></body></html>",
-        "noQuirksBodyHtml": "FOO<script type=\"text/plain\">'<!-- <sCrIpt '</script>BAR</script>"
+        "html": "<html><head></head><body>FOO<script type=\"text/plain\">'<!-- <sCrIpt '&lt;/script>BAR</script></body></html>",
+        "noQuirksBodyHtml": "FOO<script type=\"text/plain\">'<!-- <sCrIpt '&lt;/script>BAR</script>"
       }
     },
     {
@@ -18636,8 +18636,8 @@
             ]
           }
         ],
-        "html": "<html><head></head><body>FOO<script type=\"text/plain\">'<!-- <sCrIpt/'</script>BAR</script></body></html>",
-        "noQuirksBodyHtml": "FOO<script type=\"text/plain\">'<!-- <sCrIpt/'</script>BAR</script>"
+        "html": "<html><head></head><body>FOO<script type=\"text/plain\">'<!-- <sCrIpt/'&lt;/script>BAR</script></body></html>",
+        "noQuirksBodyHtml": "FOO<script type=\"text/plain\">'<!-- <sCrIpt/'&lt;/script>BAR</script>"
       }
     },
     {
@@ -18746,8 +18746,8 @@
             ]
           }
         ],
-        "html": "<html><head></head><body>FOO<script type=\"text/plain\">'<!-- <sCrIpt/'</script>BAR</script>QUX</body></html>",
-        "noQuirksBodyHtml": "FOO<script type=\"text/plain\">'<!-- <sCrIpt/'</script>BAR</script>QUX"
+        "html": "<html><head></head><body>FOO<script type=\"text/plain\">'<!-- <sCrIpt/'&lt;/script>BAR</script>QUX</body></html>",
+        "noQuirksBodyHtml": "FOO<script type=\"text/plain\">'<!-- <sCrIpt/'&lt;/script>BAR</script>QUX"
       }
     },
     {
@@ -18795,8 +18795,8 @@
             ]
           }
         ],
-        "html": "<html><head></head><body>FOO<script><!--<script>-></script>--></script>QUX</body></html>",
-        "noQuirksBodyHtml": "FOO<script><!--<script>-></script>--></script>QUX"
+        "html": "<html><head></head><body>FOO<script><!--<script>->&lt;/script>--></script>QUX</body></html>",
+        "noQuirksBodyHtml": "FOO<script><!--<script>->&lt;/script>--></script>QUX"
       }
     }
   ],
@@ -39816,8 +39816,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script></SCRIPT</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script></SCRIPT</script>"
+        "html": "<!DOCTYPE html><html><head><script>&lt;/SCRIPT</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script>&lt;/SCRIPT</script>"
       }
     },
     {
@@ -40139,8 +40139,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script></script</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script></script</script>"
+        "html": "<!DOCTYPE html><html><head><script>&lt;/script</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script>&lt;/script</script>"
       }
     },
     {
@@ -40657,8 +40657,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--</script</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--</script</script>"
+        "html": "<!DOCTYPE html><html><head><script><!--&lt;/script</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--&lt;/script</script>"
       }
     },
     {
@@ -41089,8 +41089,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script </script</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script</script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script &lt;/script</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script</script>"
       }
     },
     {
@@ -41137,8 +41137,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script </scripta</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </scripta</script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script &lt;/scripta</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/scripta</script>"
       }
     },
     {
@@ -41185,8 +41185,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script </script </script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script </script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script &lt;/script </script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script </script>"
       }
     },
     {
@@ -41233,8 +41233,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script </script></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script></script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script &lt;/script></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script></script>"
       }
     },
     {
@@ -41281,8 +41281,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script </script/</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script/</script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script &lt;/script/</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script/</script>"
       }
     },
     {
@@ -41329,8 +41329,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script </script <</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script <</script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script &lt;/script <</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script <</script>"
       }
     },
     {
@@ -41377,8 +41377,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script </script <a</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script <a</script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script &lt;/script <a</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script <a</script>"
       }
     },
     {
@@ -41425,8 +41425,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script </script </</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script </</script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script &lt;/script </</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script </</script>"
       }
     },
     {
@@ -41473,8 +41473,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script </script </script</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script </script</script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script &lt;/script &lt;/script</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script &lt;/script</script>"
       }
     },
     {
@@ -41521,8 +41521,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script </script </script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script </script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script &lt;/script </script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script </script>"
       }
     },
     {
@@ -41569,8 +41569,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script </script </script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script </script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script &lt;/script </script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script </script>"
       }
     },
     {
@@ -41614,8 +41614,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script </script </script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script </script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script &lt;/script </script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script </script>"
       }
     },
     {
@@ -42090,8 +42090,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script --></script</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script --></script</script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script -->&lt;/script</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script -->&lt;/script</script>"
       }
     },
     {
@@ -42366,8 +42366,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script></script><script></script></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script></script><script></script></script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script>&lt;/script><script>&lt;/script></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script>&lt;/script><script>&lt;/script></script>"
       }
     },
     {
@@ -42411,8 +42411,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script></script><script></script>--><!--</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script></script><script></script>--><!--</script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script>&lt;/script><script>&lt;/script>--><!--</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script>&lt;/script><script>&lt;/script>--><!--</script>"
       }
     },
     {
@@ -42456,8 +42456,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script></script><script></script>-- ></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script></script><script></script>-- ></script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script>&lt;/script><script>&lt;/script>-- ></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script>&lt;/script><script>&lt;/script>-- ></script>"
       }
     },
     {
@@ -42501,8 +42501,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script></script><script></script>- -></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script></script><script></script>- -></script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script>&lt;/script><script>&lt;/script>- -></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script>&lt;/script><script>&lt;/script>- -></script>"
       }
     },
     {
@@ -42546,8 +42546,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script></script><script></script>- - ></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script></script><script></script>- - ></script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script>&lt;/script><script>&lt;/script>- - ></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script>&lt;/script><script>&lt;/script>- - ></script>"
       }
     },
     {
@@ -42591,8 +42591,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script></script><script></script>-></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script></script><script></script>-></script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script>&lt;/script><script>&lt;/script>-></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script>&lt;/script><script>&lt;/script>-></script>"
       }
     },
     {
@@ -42639,8 +42639,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script>--!></script>X</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script>--!></script>X</script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script>--!>&lt;/script>X</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script>--!>&lt;/script>X</script>"
       }
     },
     {
@@ -42741,8 +42741,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script><!--<script></scr'+'ipt></script>X</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script></scr'+'ipt></script>X</script>"
+        "html": "<!DOCTYPE html><html><head><script><!--<script></scr'+'ipt>&lt;/script>X</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script></scr'+'ipt>&lt;/script>X</script>"
       }
     },
     {
@@ -44537,8 +44537,8 @@
             ]
           }
         ],
-        "html": "<html><head><script></SCRIPT</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script></SCRIPT</script>"
+        "html": "<html><head><script>&lt;/SCRIPT</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script>&lt;/SCRIPT</script>"
       }
     },
     {
@@ -44839,8 +44839,8 @@
             ]
           }
         ],
-        "html": "<html><head><script></script</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script></script</script>"
+        "html": "<html><head><script>&lt;/script</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script>&lt;/script</script>"
       }
     },
     {
@@ -45324,8 +45324,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--</script</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--</script</script>"
+        "html": "<html><head><script><!--&lt;/script</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--&lt;/script</script>"
       }
     },
     {
@@ -45729,8 +45729,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script </script</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script</script>"
+        "html": "<html><head><script><!--<script &lt;/script</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script</script>"
       }
     },
     {
@@ -45774,8 +45774,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script </scripta</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </scripta</script>"
+        "html": "<html><head><script><!--<script &lt;/scripta</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/scripta</script>"
       }
     },
     {
@@ -45819,8 +45819,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script </script </script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script </script>"
+        "html": "<html><head><script><!--<script &lt;/script </script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script </script>"
       }
     },
     {
@@ -45864,8 +45864,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script </script></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script></script>"
+        "html": "<html><head><script><!--<script &lt;/script></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script></script>"
       }
     },
     {
@@ -45909,8 +45909,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script </script/</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script/</script>"
+        "html": "<html><head><script><!--<script &lt;/script/</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script/</script>"
       }
     },
     {
@@ -45954,8 +45954,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script </script <</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script <</script>"
+        "html": "<html><head><script><!--<script &lt;/script <</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script <</script>"
       }
     },
     {
@@ -45999,8 +45999,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script </script <a</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script <a</script>"
+        "html": "<html><head><script><!--<script &lt;/script <a</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script <a</script>"
       }
     },
     {
@@ -46044,8 +46044,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script </script </</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script </</script>"
+        "html": "<html><head><script><!--<script &lt;/script </</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script </</script>"
       }
     },
     {
@@ -46089,8 +46089,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script </script </script</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script </script</script>"
+        "html": "<html><head><script><!--<script &lt;/script &lt;/script</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script &lt;/script</script>"
       }
     },
     {
@@ -46134,8 +46134,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script </script </script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script </script>"
+        "html": "<html><head><script><!--<script &lt;/script </script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script </script>"
       }
     },
     {
@@ -46179,8 +46179,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script </script </script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script </script>"
+        "html": "<html><head><script><!--<script &lt;/script </script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script </script>"
       }
     },
     {
@@ -46222,8 +46222,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script </script </script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script </script </script>"
+        "html": "<html><head><script><!--<script &lt;/script </script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script &lt;/script </script>"
       }
     },
     {
@@ -46578,8 +46578,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script --></script</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script --></script</script>"
+        "html": "<html><head><script><!--<script -->&lt;/script</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script -->&lt;/script</script>"
       }
     },
     {
@@ -46840,8 +46840,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script></script><script></script></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script></script><script></script></script>"
+        "html": "<html><head><script><!--<script>&lt;/script><script>&lt;/script></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script>&lt;/script><script>&lt;/script></script>"
       }
     },
     {
@@ -46883,8 +46883,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script></script><script></script>--><!--</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script></script><script></script>--><!--</script>"
+        "html": "<html><head><script><!--<script>&lt;/script><script>&lt;/script>--><!--</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script>&lt;/script><script>&lt;/script>--><!--</script>"
       }
     },
     {
@@ -46926,8 +46926,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script></script><script></script>-- ></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script></script><script></script>-- ></script>"
+        "html": "<html><head><script><!--<script>&lt;/script><script>&lt;/script>-- ></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script>&lt;/script><script>&lt;/script>-- ></script>"
       }
     },
     {
@@ -46969,8 +46969,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script></script><script></script>- -></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script></script><script></script>- -></script>"
+        "html": "<html><head><script><!--<script>&lt;/script><script>&lt;/script>- -></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script>&lt;/script><script>&lt;/script>- -></script>"
       }
     },
     {
@@ -47012,8 +47012,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script></script><script></script>- - ></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script></script><script></script>- - ></script>"
+        "html": "<html><head><script><!--<script>&lt;/script><script>&lt;/script>- - ></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script>&lt;/script><script>&lt;/script>- - ></script>"
       }
     },
     {
@@ -47055,8 +47055,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script></script><script></script>-></script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script></script><script></script>-></script>"
+        "html": "<html><head><script><!--<script>&lt;/script><script>&lt;/script>-></script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script>&lt;/script><script>&lt;/script>-></script>"
       }
     },
     {
@@ -47100,8 +47100,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script>--!></script>X</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script>--!></script>X</script>"
+        "html": "<html><head><script><!--<script>--!>&lt;/script>X</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script>--!>&lt;/script>X</script>"
       }
     },
     {
@@ -47196,8 +47196,8 @@
             ]
           }
         ],
-        "html": "<html><head><script><!--<script></scr'+'ipt></script>X</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script><!--<script></scr'+'ipt></script>X</script>"
+        "html": "<html><head><script><!--<script></scr'+'ipt>&lt;/script>X</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script><!--<script></scr'+'ipt>&lt;/script>X</script>"
       }
     },
     {
@@ -49299,8 +49299,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head></head><body><plaintext></plaintext></plaintext></body></html>",
-        "noQuirksBodyHtml": "<plaintext></plaintext></plaintext>"
+        "html": "<!DOCTYPE html><html><head></head><body><plaintext>&lt;/plaintext></plaintext></body></html>",
+        "noQuirksBodyHtml": "<plaintext>&lt;/plaintext></plaintext>"
       }
     },
     {
@@ -49363,8 +49363,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head></head><body><plaintext></plaintext></plaintext><table></table></body></html>",
-        "noQuirksBodyHtml": "<plaintext></plaintext></plaintext><table></table>"
+        "html": "<!DOCTYPE html><html><head></head><body><plaintext>&lt;/plaintext></plaintext><table></table></body></html>",
+        "noQuirksBodyHtml": "<plaintext>&lt;/plaintext></plaintext><table></table>"
       }
     },
     {
@@ -49433,8 +49433,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head></head><body><plaintext></plaintext></plaintext><table><tbody></tbody></table></body></html>",
-        "noQuirksBodyHtml": "<plaintext></plaintext></plaintext><table><tbody></tbody></table>"
+        "html": "<!DOCTYPE html><html><head></head><body><plaintext>&lt;/plaintext></plaintext><table><tbody></tbody></table></body></html>",
+        "noQuirksBodyHtml": "<plaintext>&lt;/plaintext></plaintext><table><tbody></tbody></table>"
       }
     },
     {
@@ -49509,8 +49509,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head></head><body><plaintext></plaintext></plaintext><table><tbody><tr></tr></tbody></table></body></html>",
-        "noQuirksBodyHtml": "<plaintext></plaintext></plaintext><table><tbody><tr></tr></tbody></table>"
+        "html": "<!DOCTYPE html><html><head></head><body><plaintext>&lt;/plaintext></plaintext><table><tbody><tr></tr></tbody></table></body></html>",
+        "noQuirksBodyHtml": "<plaintext>&lt;/plaintext></plaintext><table><tbody><tr></tr></tbody></table>"
       }
     },
     {
@@ -49581,8 +49581,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head></head><body><table><tbody><tr><td><plaintext></plaintext></plaintext></td></tr></tbody></table></body></html>",
-        "noQuirksBodyHtml": "<table><tbody><tr><td><plaintext></plaintext></plaintext></td></tr></tbody></table>"
+        "html": "<!DOCTYPE html><html><head></head><body><table><tbody><tr><td><plaintext>&lt;/plaintext></plaintext></td></tr></tbody></table></body></html>",
+        "noQuirksBodyHtml": "<table><tbody><tr><td><plaintext>&lt;/plaintext></plaintext></td></tr></tbody></table>"
       }
     },
     {
@@ -49640,8 +49640,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head></head><body><table><caption><plaintext></plaintext></plaintext></caption></table></body></html>",
-        "noQuirksBodyHtml": "<table><caption><plaintext></plaintext></plaintext></caption></table>"
+        "html": "<!DOCTYPE html><html><head></head><body><table><caption><plaintext>&lt;/plaintext></plaintext></caption></table></body></html>",
+        "noQuirksBodyHtml": "<table><caption><plaintext>&lt;/plaintext></plaintext></caption></table>"
       }
     },
     {
@@ -56267,8 +56267,8 @@
             ]
           }
         ],
-        "html": "<html><head></head><body><plaintext></plaintext></plaintext></body></html>",
-        "noQuirksBodyHtml": "<plaintext></plaintext></plaintext>"
+        "html": "<html><head></head><body><plaintext>&lt;/plaintext></plaintext></body></html>",
+        "noQuirksBodyHtml": "<plaintext>&lt;/plaintext></plaintext>"
       }
     },
     {
@@ -56506,8 +56506,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><script type=\"text/x-foobar;baz\">X</SCRipt</script></head><body></body></html>",
-        "noQuirksBodyHtml": "<script type=\"text/x-foobar;baz\">X</SCRipt</script>"
+        "html": "<!DOCTYPE html><html><head><script type=\"text/x-foobar;baz\">X&lt;/SCRipt</script></head><body></body></html>",
+        "noQuirksBodyHtml": "<script type=\"text/x-foobar;baz\">X&lt;/SCRipt</script>"
       }
     },
     {
@@ -57740,8 +57740,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head></head><body><title>X</title><meta name=\"z\"><link rel=\"foo\"><style>\nx { content:\"</style\" } </style></body></html>",
-        "noQuirksBodyHtml": "<title>X</title><meta name=\"z\"><link rel=\"foo\"><style>\nx { content:\"</style\" } </style>"
+        "html": "<!DOCTYPE html><html><head></head><body><title>X</title><meta name=\"z\"><link rel=\"foo\"><style>\nx { content:\"&lt;/style\" } </style></body></html>",
+        "noQuirksBodyHtml": "<title>X</title><meta name=\"z\"><link rel=\"foo\"><style>\nx { content:\"&lt;/style\" } </style>"
       }
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,9 +11,87 @@ __metadata:
   dependencies:
     jquery: ^3.5.1
     mocha: ^6.2.3
+    puppeteer: ^21.3.5
     should: ^13.2.3
   languageName: unknown
   linkType: soft
+
+"@babel/code-frame@npm:^7.0.0":
+  version: 7.22.13
+  resolution: "@babel/code-frame@npm:7.22.13"
+  dependencies:
+    "@babel/highlight": ^7.22.13
+    chalk: ^2.4.2
+  checksum: 22e342c8077c8b77eeb11f554ecca2ba14153f707b85294fcf6070b6f6150aae88a7b7436dd88d8c9289970585f3fe5b9b941c5aa3aa26a6d5a8ef3f292da058
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.22.20":
+  version: 7.22.20
+  resolution: "@babel/helper-validator-identifier@npm:7.22.20"
+  checksum: 136412784d9428266bcdd4d91c32bcf9ff0e8d25534a9d94b044f77fe76bc50f941a90319b05aafd1ec04f7d127cd57a179a3716009ff7f3412ef835ada95bdc
+  languageName: node
+  linkType: hard
+
+"@babel/highlight@npm:^7.22.13":
+  version: 7.22.20
+  resolution: "@babel/highlight@npm:7.22.20"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.22.20
+    chalk: ^2.4.2
+    js-tokens: ^4.0.0
+  checksum: 84bd034dca309a5e680083cd827a766780ca63cef37308404f17653d32366ea76262bd2364b2d38776232f2d01b649f26721417d507e8b4b6da3e4e739f6d134
+  languageName: node
+  linkType: hard
+
+"@puppeteer/browsers@npm:1.7.1":
+  version: 1.7.1
+  resolution: "@puppeteer/browsers@npm:1.7.1"
+  dependencies:
+    debug: 4.3.4
+    extract-zip: 2.0.1
+    progress: 2.0.3
+    proxy-agent: 6.3.1
+    tar-fs: 3.0.4
+    unbzip2-stream: 1.4.3
+    yargs: 17.7.1
+  bin:
+    browsers: lib/cjs/main-cli.js
+  checksum: fb7cf7773a1aed4e34ce0952dbf9609a164e624d4f8e1f342b816fe3e983888d7a7b2fbafc963559e96cb5bca0d75fb9c81f2097f9b1f5478a0f1cc7cbc12dff
+  languageName: node
+  linkType: hard
+
+"@tootallnate/quickjs-emscripten@npm:^0.23.0":
+  version: 0.23.0
+  resolution: "@tootallnate/quickjs-emscripten@npm:0.23.0"
+  checksum: c350a2947ffb80b22e14ff35099fd582d1340d65723384a0fd0515e905e2534459ad2f301a43279a37308a27c99273c932e64649abd57d0bb3ca8c557150eccc
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:*":
+  version: 20.7.2
+  resolution: "@types/node@npm:20.7.2"
+  checksum: 5baa09368c8daa50ad1eaa2499b988b2f4c06cacf8b251d1e63f68ad32df97b21d8104f1ac06889481f1d3e84056842732bb848dd1136164d823c1d4a6baf435
+  languageName: node
+  linkType: hard
+
+"@types/yauzl@npm:^2.9.1":
+  version: 2.10.1
+  resolution: "@types/yauzl@npm:2.10.1"
+  dependencies:
+    "@types/node": "*"
+  checksum: 3377916a2d493cb2422b167fb7dfff8cb3ea045a9489dab4955858719bf7fe6808e5f6a51ee819904fb7f623f7ac092b87f9d6a857ea1214a45070d19c8b3d7e
+  languageName: node
+  linkType: hard
+
+"agent-base@npm:^7.0.2, agent-base@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "agent-base@npm:7.1.0"
+  dependencies:
+    debug: ^4.3.4
+  checksum: f7828f991470a0cc22cb579c86a18cbae83d8a3cbed39992ab34fc7217c4d126017f1c74d0ab66be87f71455318a8ea3e757d6a37881b8d0f2a2c6aa55e5418f
+  languageName: node
+  linkType: hard
 
 "ansi-colors@npm:3.2.3":
   version: 3.2.3
@@ -36,6 +114,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-regex@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "ansi-regex@npm:5.0.1"
+  checksum: 2aa4bb54caf2d622f1afdad09441695af2a83aa3fe8b8afa581d205e57ed4261c183c4d3877cee25794443fde5876417d859c108078ab788d6af7e4fe52eb66b
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^3.2.0, ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
@@ -45,12 +130,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-styles@npm:^4.0.0":
+  version: 4.3.0
+  resolution: "ansi-styles@npm:4.3.0"
+  dependencies:
+    color-convert: ^2.0.1
+  checksum: 513b44c3b2105dd14cc42a19271e80f386466c4be574bccf60b627432f9198571ebf4ab1e4c3ba17347658f4ee1711c163d574248c0c1cdc2d5917a0ad582ec4
+  languageName: node
+  linkType: hard
+
 "argparse@npm:^1.0.7":
   version: 1.0.10
   resolution: "argparse@npm:1.0.10"
   dependencies:
     sprintf-js: ~1.0.2
   checksum: 7ca6e45583a28de7258e39e13d81e925cfa25d7d4aacbf806a382d3c02fcb13403a07fb8aeef949f10a7cfe4a62da0e2e807b348a5980554cc28ee573ef95945
+  languageName: node
+  linkType: hard
+
+"argparse@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "argparse@npm:2.0.1"
+  checksum: 83644b56493e89a254bae05702abf3a1101b4fa4d0ca31df1c9985275a5a5bd47b3c27b7fa0b71098d41114d8ca000e6ed90cad764b306f8a503665e4d517ced
   languageName: node
   linkType: hard
 
@@ -67,6 +168,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ast-types@npm:^0.13.4":
+  version: 0.13.4
+  resolution: "ast-types@npm:0.13.4"
+  dependencies:
+    tslib: ^2.0.1
+  checksum: 5a51f7b70588ecced3601845a0e203279ca2f5fdc184416a0a1640c93ec0a267241d6090a328e78eebb8de81f8754754e0a4f1558ba2a3d638f8ccbd0b1f0eff
+  languageName: node
+  linkType: hard
+
 "available-typed-arrays@npm:^1.0.5":
   version: 1.0.5
   resolution: "available-typed-arrays@npm:1.0.5"
@@ -74,10 +184,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"b4a@npm:^1.6.4":
+  version: 1.6.4
+  resolution: "b4a@npm:1.6.4"
+  checksum: 81b086f9af1f8845fbef4476307236bda3d660c158c201db976f19cdce05f41f93110ab6b12fd7a2696602a490cc43d5410ee36a56d6eef93afb0d6ca69ac3b2
+  languageName: node
+  linkType: hard
+
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
   checksum: 9706c088a283058a8a99e0bf91b0a2f75497f185980d9ffa8b304de1d9e58ebda7c72c07ebf01dadedaac5b2907b2c6f566f660d62bd336c3468e960403b9d65
+  languageName: node
+  linkType: hard
+
+"base64-js@npm:^1.3.1":
+  version: 1.5.1
+  resolution: "base64-js@npm:1.5.1"
+  checksum: 669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
+  languageName: node
+  linkType: hard
+
+"basic-ftp@npm:^5.0.2":
+  version: 5.0.3
+  resolution: "basic-ftp@npm:5.0.3"
+  checksum: 8b04e88eb85a64de9311721bb0707c9cd70453eefdd854cab85438e6f46fb6c597ddad57ed1acf0a9ede3c677b14e657f51051688a5f23d6f3ea7b5d9073b850
   languageName: node
   linkType: hard
 
@@ -98,6 +229,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-crc32@npm:~0.2.3":
+  version: 0.2.13
+  resolution: "buffer-crc32@npm:0.2.13"
+  checksum: 06252347ae6daca3453b94e4b2f1d3754a3b146a111d81c68924c22d91889a40623264e95e67955b1cb4a68cbedf317abeabb5140a9766ed248973096db5ce1c
+  languageName: node
+  linkType: hard
+
+"buffer@npm:^5.2.1":
+  version: 5.7.1
+  resolution: "buffer@npm:5.7.1"
+  dependencies:
+    base64-js: ^1.3.1
+    ieee754: ^1.1.13
+  checksum: e2cf8429e1c4c7b8cbd30834ac09bd61da46ce35f5c22a78e6c2f04497d6d25541b16881e30a019c6fd3154150650ccee27a308eff3e26229d788bbdeb08ab84
+  languageName: node
+  linkType: hard
+
 "call-bind@npm:^1.0.0, call-bind@npm:^1.0.2":
   version: 1.0.2
   resolution: "call-bind@npm:1.0.2"
@@ -108,6 +256,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"callsites@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "callsites@npm:3.1.0"
+  checksum: 072d17b6abb459c2ba96598918b55868af677154bec7e73d222ef95a8fdb9bbf7dae96a8421085cdad8cd190d86653b5b6dc55a4484f2e5b2e27d5e0c3fc15b3
+  languageName: node
+  linkType: hard
+
 "camelcase@npm:^5.0.0":
   version: 5.3.1
   resolution: "camelcase@npm:5.3.1"
@@ -115,7 +270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^2.0.1":
+"chalk@npm:^2.0.1, chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
   dependencies:
@@ -123,6 +278,18 @@ __metadata:
     escape-string-regexp: ^1.0.5
     supports-color: ^5.3.0
   checksum: ec3661d38fe77f681200f878edbd9448821924e0f93a9cefc0e26a33b145f1027a2084bf19967160d11e1f03bfe4eaffcabf5493b89098b2782c3fe0b03d80c2
+  languageName: node
+  linkType: hard
+
+"chromium-bidi@npm:0.4.28":
+  version: 0.4.28
+  resolution: "chromium-bidi@npm:0.4.28"
+  dependencies:
+    mitt: 3.0.1
+    urlpattern-polyfill: 9.0.0
+  peerDependencies:
+    devtools-protocol: "*"
+  checksum: d8ac0aefcf11ebd744e0b97ecded9dac5c03ab55f46267570cdf1b780ad1e05e8cf6987b65178bda99a1ef1ea1bc59721bda85008283ca5f145912b9e1bf578d
   languageName: node
   linkType: hard
 
@@ -137,12 +304,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cliui@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "cliui@npm:8.0.1"
+  dependencies:
+    string-width: ^4.2.0
+    strip-ansi: ^6.0.1
+    wrap-ansi: ^7.0.0
+  checksum: 79648b3b0045f2e285b76fb2e24e207c6db44323581e421c3acbd0e86454cba1b37aea976ab50195a49e7384b871e6dfb2247ad7dec53c02454ac6497394cb56
+  languageName: node
+  linkType: hard
+
 "color-convert@npm:^1.9.0":
   version: 1.9.3
   resolution: "color-convert@npm:1.9.3"
   dependencies:
     color-name: 1.1.3
   checksum: fd7a64a17cde98fb923b1dd05c5f2e6f7aefda1b60d67e8d449f9328b4e53b228a428fd38bfeaeb2db2ff6b6503a776a996150b80cdf224062af08a5c8a3a203
+  languageName: node
+  linkType: hard
+
+"color-convert@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "color-convert@npm:2.0.1"
+  dependencies:
+    color-name: ~1.1.4
+  checksum: 79e6bdb9fd479a205c71d89574fccfb22bd9053bd98c6c4d870d65c132e5e904e6034978e55b43d69fcaa7433af2016ee203ce76eeba9cfa554b373e7f7db336
   languageName: node
   linkType: hard
 
@@ -153,10 +340,50 @@ __metadata:
   languageName: node
   linkType: hard
 
+"color-name@npm:~1.1.4":
+  version: 1.1.4
+  resolution: "color-name@npm:1.1.4"
+  checksum: b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
+  languageName: node
+  linkType: hard
+
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
   checksum: 902a9f5d8967a3e2faf138d5cb784b9979bad2e6db5357c5b21c568df4ebe62bcb15108af1b2253744844eb964fc023fbd9afbbbb6ddd0bcc204c6fb5b7bf3af
+  languageName: node
+  linkType: hard
+
+"cosmiconfig@npm:8.3.6":
+  version: 8.3.6
+  resolution: "cosmiconfig@npm:8.3.6"
+  dependencies:
+    import-fresh: ^3.3.0
+    js-yaml: ^4.1.0
+    parse-json: ^5.2.0
+    path-type: ^4.0.0
+  peerDependencies:
+    typescript: ">=4.9.5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: dc339ebea427898c9e03bf01b56ba7afbac07fc7d2a2d5a15d6e9c14de98275a9565da949375aee1809591c152c0a3877bb86dbeaf74d5bd5aaa79955ad9e7a0
+  languageName: node
+  linkType: hard
+
+"cross-fetch@npm:4.0.0":
+  version: 4.0.0
+  resolution: "cross-fetch@npm:4.0.0"
+  dependencies:
+    node-fetch: ^2.6.12
+  checksum: ecca4f37ffa0e8283e7a8a590926b66713a7ef7892757aa36c2d20ffa27b0ac5c60dcf453119c809abe5923fc0bae3702a4d896bfb406ef1077b0d0018213e24
+  languageName: node
+  linkType: hard
+
+"data-uri-to-buffer@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "data-uri-to-buffer@npm:5.0.1"
+  checksum: 10958f89c0047b84bd86d572b6b77c9bf238ebe7b55a9a9ab04c90fbf5ab1881783b72e31dc0febdffd30ec914930244f2f728e3629bb8911d922baba129426f
   languageName: node
   linkType: hard
 
@@ -166,6 +393,18 @@ __metadata:
   dependencies:
     ms: ^2.1.1
   checksum: 07bc8b3a13ef3cfa6c06baf7871dfb174c291e5f85dbf566f086620c16b9c1a0e93bb8f1935ebbd07a683249e7e30286f2966e2ef461e8fd17b1b60732062d6b
+  languageName: node
+  linkType: hard
+
+"debug@npm:4, debug@npm:4.3.4, debug@npm:^4.1.1, debug@npm:^4.3.4":
+  version: 4.3.4
+  resolution: "debug@npm:4.3.4"
+  dependencies:
+    ms: 2.1.2
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 3dbad3f94ea64f34431a9cbf0bafb61853eda57bff2880036153438f50fb5a84f27683ba0d8e5426bf41a8c6ff03879488120cf5b3a761e77953169c0600a708
   languageName: node
   linkType: hard
 
@@ -186,6 +425,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"degenerator@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "degenerator@npm:5.0.1"
+  dependencies:
+    ast-types: ^0.13.4
+    escodegen: ^2.1.0
+    esprima: ^4.0.1
+  checksum: a64fa39cdf6c2edd75188157d32338ee9de7193d7dbb2aeb4acb1eb30fa4a15ed80ba8dae9bd4d7b085472cf174a5baf81adb761aaa8e326771392c922084152
+  languageName: node
+  linkType: hard
+
+"devtools-protocol@npm:0.0.1179426":
+  version: 0.0.1179426
+  resolution: "devtools-protocol@npm:0.0.1179426"
+  checksum: 38a091bde42d7d0f8e5e6c7a445db6a56d7b80f21f51de47ed1316123f70b2256aa6fe0d87fbe37bcc4928c0b9245e28a17fb7fbf8d8622156ae36870b26c1ed
+  languageName: node
+  linkType: hard
+
 "diff@npm:3.5.0":
   version: 3.5.0
   resolution: "diff@npm:3.5.0"
@@ -197,6 +454,31 @@ __metadata:
   version: 7.0.3
   resolution: "emoji-regex@npm:7.0.3"
   checksum: 9159b2228b1511f2870ac5920f394c7e041715429a68459ebe531601555f11ea782a8e1718f969df2711d38c66268174407cbca57ce36485544f695c2dfdc96e
+  languageName: node
+  linkType: hard
+
+"emoji-regex@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "emoji-regex@npm:8.0.0"
+  checksum: d4c5c39d5a9868b5fa152f00cada8a936868fd3367f33f71be515ecee4c803132d11b31a6222b2571b1e5f7e13890156a94880345594d0ce7e3c9895f560f192
+  languageName: node
+  linkType: hard
+
+"end-of-stream@npm:^1.1.0":
+  version: 1.4.4
+  resolution: "end-of-stream@npm:1.4.4"
+  dependencies:
+    once: ^1.4.0
+  checksum: 530a5a5a1e517e962854a31693dbb5c0b2fc40b46dad2a56a2deec656ca040631124f4795823acc68238147805f8b021abbe221f4afed5ef3c8e8efc2024908b
+  languageName: node
+  linkType: hard
+
+"error-ex@npm:^1.3.1":
+  version: 1.3.2
+  resolution: "error-ex@npm:1.3.2"
+  dependencies:
+    is-arrayish: ^0.2.1
+  checksum: c1c2b8b65f9c91b0f9d75f0debaa7ec5b35c266c2cac5de412c1a6de86d4cbae04ae44e510378cb14d032d0645a36925d0186f8bb7367bcc629db256b743a001
   languageName: node
   linkType: hard
 
@@ -270,6 +552,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escalade@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "escalade@npm:3.1.1"
+  checksum: a3e2a99f07acb74b3ad4989c48ca0c3140f69f923e56d0cba0526240ee470b91010f9d39001f2a4a313841d237ede70a729e92125191ba5d21e74b106800b133
+  languageName: node
+  linkType: hard
+
 "escape-string-regexp@npm:1.0.5, escape-string-regexp@npm:^1.0.5":
   version: 1.0.5
   resolution: "escape-string-regexp@npm:1.0.5"
@@ -277,13 +566,78 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esprima@npm:^4.0.0":
+"escodegen@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "escodegen@npm:2.1.0"
+  dependencies:
+    esprima: ^4.0.1
+    estraverse: ^5.2.0
+    esutils: ^2.0.2
+    source-map: ~0.6.1
+  dependenciesMeta:
+    source-map:
+      optional: true
+  bin:
+    escodegen: bin/escodegen.js
+    esgenerate: bin/esgenerate.js
+  checksum: 096696407e161305cd05aebb95134ad176708bc5cb13d0dcc89a5fcbb959b8ed757e7f2591a5f8036f8f4952d4a724de0df14cd419e29212729fa6df5ce16bf6
+  languageName: node
+  linkType: hard
+
+"esprima@npm:^4.0.0, esprima@npm:^4.0.1":
   version: 4.0.1
   resolution: "esprima@npm:4.0.1"
   bin:
     esparse: ./bin/esparse.js
     esvalidate: ./bin/esvalidate.js
   checksum: b45bc805a613dbea2835278c306b91aff6173c8d034223fa81498c77dcbce3b2931bf6006db816f62eacd9fd4ea975dfd85a5b7f3c6402cfd050d4ca3c13a628
+  languageName: node
+  linkType: hard
+
+"estraverse@npm:^5.2.0":
+  version: 5.3.0
+  resolution: "estraverse@npm:5.3.0"
+  checksum: 072780882dc8416ad144f8fe199628d2b3e7bbc9989d9ed43795d2c90309a2047e6bc5979d7e2322a341163d22cfad9e21f4110597fe487519697389497e4e2b
+  languageName: node
+  linkType: hard
+
+"esutils@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "esutils@npm:2.0.3"
+  checksum: 22b5b08f74737379a840b8ed2036a5fb35826c709ab000683b092d9054e5c2a82c27818f12604bfc2a9a76b90b6834ef081edbc1c7ae30d1627012e067c6ec87
+  languageName: node
+  linkType: hard
+
+"extract-zip@npm:2.0.1":
+  version: 2.0.1
+  resolution: "extract-zip@npm:2.0.1"
+  dependencies:
+    "@types/yauzl": ^2.9.1
+    debug: ^4.1.1
+    get-stream: ^5.1.0
+    yauzl: ^2.10.0
+  dependenciesMeta:
+    "@types/yauzl":
+      optional: true
+  bin:
+    extract-zip: cli.js
+  checksum: 8cbda9debdd6d6980819cc69734d874ddd71051c9fe5bde1ef307ebcedfe949ba57b004894b585f758b7c9eeeea0e3d87f2dda89b7d25320459c2c9643ebb635
+  languageName: node
+  linkType: hard
+
+"fast-fifo@npm:^1.1.0, fast-fifo@npm:^1.2.0":
+  version: 1.3.2
+  resolution: "fast-fifo@npm:1.3.2"
+  checksum: 6bfcba3e4df5af7be3332703b69a7898a8ed7020837ec4395bb341bd96cc3a6d86c3f6071dd98da289618cf2234c70d84b2a6f09a33dd6f988b1ff60d8e54275
+  languageName: node
+  linkType: hard
+
+"fd-slicer@npm:~1.1.0":
+  version: 1.1.0
+  resolution: "fd-slicer@npm:1.1.0"
+  dependencies:
+    pend: ~1.2.0
+  checksum: c8585fd5713f4476eb8261150900d2cb7f6ff2d87f8feb306ccc8a1122efd152f1783bdb2b8dc891395744583436bfd8081d8e63ece0ec8687eeefea394d4ff2
   languageName: node
   linkType: hard
 
@@ -313,6 +667,17 @@ __metadata:
   dependencies:
     is-callable: ^1.1.3
   checksum: 6c48ff2bc63362319c65e2edca4a8e1e3483a2fabc72fbe7feaf8c73db94fc7861bd53bc02c8a66a0c1dd709da6b04eec42e0abdd6b40ce47305ae92a25e5d28
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "fs-extra@npm:8.1.0"
+  dependencies:
+    graceful-fs: ^4.2.0
+    jsonfile: ^4.0.0
+    universalify: ^0.1.0
+  checksum: bf44f0e6cea59d5ce071bba4c43ca76d216f89e402dc6285c128abc0902e9b8525135aa808adad72c9d5d218e9f4bcc63962815529ff2f684ad532172a284880
   languageName: node
   linkType: hard
 
@@ -349,7 +714,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-caller-file@npm:^2.0.1":
+"get-caller-file@npm:^2.0.1, get-caller-file@npm:^2.0.5":
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
   checksum: b9769a836d2a98c3ee734a88ba712e62703f1df31b94b784762c433c27a386dd6029ff55c2a920c392e33657d80191edbf18c61487e198844844516f843496b9
@@ -367,6 +732,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-stream@npm:^5.1.0":
+  version: 5.2.0
+  resolution: "get-stream@npm:5.2.0"
+  dependencies:
+    pump: ^3.0.0
+  checksum: 8bc1a23174a06b2b4ce600df38d6c98d2ef6d84e020c1ddad632ad75bac4e092eeb40e4c09e0761c35fc2dbc5e7fff5dab5e763a383582c4a167dd69a905bd12
+  languageName: node
+  linkType: hard
+
 "get-symbol-description@npm:^1.0.0":
   version: 1.0.0
   resolution: "get-symbol-description@npm:1.0.0"
@@ -374,6 +748,18 @@ __metadata:
     call-bind: ^1.0.2
     get-intrinsic: ^1.1.1
   checksum: 9ceff8fe968f9270a37a1f73bf3f1f7bda69ca80f4f80850670e0e7b9444ff99323f7ac52f96567f8b5f5fbe7ac717a0d81d3407c7313e82810c6199446a5247
+  languageName: node
+  linkType: hard
+
+"get-uri@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "get-uri@npm:6.0.1"
+  dependencies:
+    basic-ftp: ^5.0.2
+    data-uri-to-buffer: ^5.0.1
+    debug: ^4.3.4
+    fs-extra: ^8.1.0
+  checksum: a8aec70e1c67386fbe67f66e344ecd671a19f4cfc8e0f0e14d070563af5123d540e77fbceb6e26566f29846fac864d2862699ab134d307f85c85e7d72ce23d14
   languageName: node
   linkType: hard
 
@@ -406,6 +792,13 @@ __metadata:
   dependencies:
     get-intrinsic: ^1.1.3
   checksum: a5ccfb8806e0917a94e0b3de2af2ea4979c1da920bc381667c260e00e7cafdbe844e2cb9c5bcfef4e5412e8bf73bab837285bc35c7ba73aaaf0134d4583393a6
+  languageName: node
+  linkType: hard
+
+"graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0":
+  version: 4.2.11
+  resolution: "graceful-fs@npm:4.2.11"
+  checksum: ac85f94da92d8eb6b7f5a8b20ce65e43d66761c55ce85ac96df6865308390da45a8d3f0296dd3a663de65d30ba497bd46c696cc1e248c72b13d6d567138a4fc7
   languageName: node
   linkType: hard
 
@@ -480,6 +873,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"http-proxy-agent@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "http-proxy-agent@npm:7.0.0"
+  dependencies:
+    agent-base: ^7.1.0
+    debug: ^4.3.4
+  checksum: 48d4fac997917e15f45094852b63b62a46d0c8a4f0b9c6c23ca26d27b8df8d178bed88389e604745e748bd9a01f5023e25093722777f0593c3f052009ff438b6
+  languageName: node
+  linkType: hard
+
+"https-proxy-agent@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "https-proxy-agent@npm:7.0.2"
+  dependencies:
+    agent-base: ^7.0.2
+    debug: 4
+  checksum: 088969a0dd476ea7a0ed0a2cf1283013682b08f874c3bc6696c83fa061d2c157d29ef0ad3eb70a2046010bb7665573b2388d10fdcb3e410a66995e5248444292
+  languageName: node
+  linkType: hard
+
+"ieee754@npm:^1.1.13":
+  version: 1.2.1
+  resolution: "ieee754@npm:1.2.1"
+  checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e
+  languageName: node
+  linkType: hard
+
+"import-fresh@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "import-fresh@npm:3.3.0"
+  dependencies:
+    parent-module: ^1.0.0
+    resolve-from: ^4.0.0
+  checksum: 2cacfad06e652b1edc50be650f7ec3be08c5e5a6f6d12d035c440a42a8cc028e60a5b99ca08a77ab4d6b1346da7d971915828f33cdab730d3d42f08242d09baa
+  languageName: node
+  linkType: hard
+
 "inflight@npm:^1.0.4":
   version: 1.0.6
   resolution: "inflight@npm:1.0.6"
@@ -508,6 +938,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ip@npm:^1.1.8":
+  version: 1.1.8
+  resolution: "ip@npm:1.1.8"
+  checksum: a2ade53eb339fb0cbe9e69a44caab10d6e3784662285eb5d2677117ee4facc33a64679051c35e0dfdb1a3983a51ce2f5d2cb36446d52e10d01881789b76e28fb
+  languageName: node
+  linkType: hard
+
+"ip@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "ip@npm:2.0.0"
+  checksum: cfcfac6b873b701996d71ec82a7dd27ba92450afdb421e356f44044ed688df04567344c36cbacea7d01b1c39a4c732dc012570ebe9bebfb06f27314bca625349
+  languageName: node
+  linkType: hard
+
 "is-array-buffer@npm:^3.0.1":
   version: 3.0.1
   resolution: "is-array-buffer@npm:3.0.1"
@@ -516,6 +960,13 @@ __metadata:
     get-intrinsic: ^1.1.3
     is-typed-array: ^1.1.10
   checksum: f26ab87448e698285daf707e52a533920449f7abf63714140ffab9d5571aa5a71ac2fa2677e8b793ad0d5d3e40078d4d2c8a0ab39c957e3cfc6513bb6c9dfdc9
+  languageName: node
+  linkType: hard
+
+"is-arrayish@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "is-arrayish@npm:0.2.1"
+  checksum: eef4417e3c10e60e2c810b6084942b3ead455af16c4509959a27e490e7aee87cfb3f38e01bbde92220b528a0ee1a18d52b787e1458ee86174d8c7f0e58cd488f
   languageName: node
   linkType: hard
 
@@ -565,6 +1016,13 @@ __metadata:
   version: 2.0.0
   resolution: "is-fullwidth-code-point@npm:2.0.0"
   checksum: eef9c6e15f68085fec19ff6a978a6f1b8f48018fd1265035552078ee945573594933b09bbd6f562553e2a241561439f1ef5339276eba68d272001343084cfab8
+  languageName: node
+  linkType: hard
+
+"is-fullwidth-code-point@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-fullwidth-code-point@npm:3.0.0"
+  checksum: 44a30c29457c7fb8f00297bce733f0a64cd22eca270f83e58c105e0d015e45c019491a4ab2faef91ab51d4738c670daff901c799f6a700e27f7314029e99e348
   languageName: node
   linkType: hard
 
@@ -657,6 +1115,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-tokens@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "js-tokens@npm:4.0.0"
+  checksum: 8a95213a5a77deb6cbe94d86340e8d9ace2b93bc367790b260101d2f36a2eaf4e4e22d9fa9cf459b38af3a32fb4190e638024cf82ec95ef708680e405ea7cc78
+  languageName: node
+  linkType: hard
+
 "js-yaml@npm:3.13.1":
   version: 3.13.1
   resolution: "js-yaml@npm:3.13.1"
@@ -666,6 +1131,43 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 7511b764abb66d8aa963379f7d2a404f078457d106552d05a7b556d204f7932384e8477513c124749fa2de52eb328961834562bd09924902c6432e40daa408bc
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "js-yaml@npm:4.1.0"
+  dependencies:
+    argparse: ^2.0.1
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: c7830dfd456c3ef2c6e355cc5a92e6700ceafa1d14bba54497b34a99f0376cecbb3e9ac14d3e5849b426d5a5140709a66237a8c991c675431271c4ce5504151a
+  languageName: node
+  linkType: hard
+
+"json-parse-even-better-errors@npm:^2.3.0":
+  version: 2.3.1
+  resolution: "json-parse-even-better-errors@npm:2.3.1"
+  checksum: 798ed4cf3354a2d9ccd78e86d2169515a0097a5c133337807cdf7f1fc32e1391d207ccfc276518cc1d7d8d4db93288b8a50ba4293d212ad1336e52a8ec0a941f
+  languageName: node
+  linkType: hard
+
+"jsonfile@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "jsonfile@npm:4.0.0"
+  dependencies:
+    graceful-fs: ^4.1.6
+  dependenciesMeta:
+    graceful-fs:
+      optional: true
+  checksum: 6447d6224f0d31623eef9b51185af03ac328a7553efcee30fa423d98a9e276ca08db87d71e17f2310b0263fd3ffa6c2a90a6308367f661dc21580f9469897c9e
+  languageName: node
+  linkType: hard
+
+"lines-and-columns@npm:^1.1.6":
+  version: 1.2.4
+  resolution: "lines-and-columns@npm:1.2.4"
+  checksum: 0c37f9f7fa212b38912b7145e1cd16a5f3cd34d782441c3e6ca653485d326f58b3caccda66efce1c5812bde4961bbde3374fae4b0d11bf1226152337f3894aa5
   languageName: node
   linkType: hard
 
@@ -695,6 +1197,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^7.14.1":
+  version: 7.18.3
+  resolution: "lru-cache@npm:7.18.3"
+  checksum: e550d772384709deea3f141af34b6d4fa392e2e418c1498c078de0ee63670f1f46f5eee746e8ef7e69e1c895af0d4224e62ee33e66a543a14763b0f2e74c1356
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:3.0.4":
   version: 3.0.4
   resolution: "minimatch@npm:3.0.4"
@@ -717,6 +1226,20 @@ __metadata:
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 75a6d645fb122dad29c06a7597bddea977258957ed88d7a6df59b5cd3fe4a527e253e9bbf2e783e4b73657f9098b96a5fe96ab8a113655d4109108577ecf85b0
+  languageName: node
+  linkType: hard
+
+"mitt@npm:3.0.1":
+  version: 3.0.1
+  resolution: "mitt@npm:3.0.1"
+  checksum: b55a489ac9c2949ab166b7f060601d3b6d893a852515ae9eca4e11df01c013876df777ea109317622b5c1c60e8aae252558e33c8c94e14124db38f64a39614b1
+  languageName: node
+  linkType: hard
+
+"mkdirp-classic@npm:^0.5.2":
+  version: 0.5.3
+  resolution: "mkdirp-classic@npm:0.5.3"
+  checksum: 3f4e088208270bbcc148d53b73e9a5bd9eef05ad2cbf3b3d0ff8795278d50dd1d11a8ef1875ff5aea3fa888931f95bfcb2ad5b7c1061cfefd6284d199e6776ac
   languageName: node
   linkType: hard
 
@@ -772,10 +1295,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ms@npm:2.1.2":
+  version: 2.1.2
+  resolution: "ms@npm:2.1.2"
+  checksum: 673cdb2c3133eb050c745908d8ce632ed2c02d85640e2edb3ace856a2266a813b30c613569bf3354fdf4ea7d1a1494add3bfa95e2713baa27d0c2c71fc44f58f
+  languageName: node
+  linkType: hard
+
 "ms@npm:^2.1.1":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
+  languageName: node
+  linkType: hard
+
+"netmask@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "netmask@npm:2.0.2"
+  checksum: c65cb8d3f7ea5669edddb3217e4c96910a60d0d9a4b52d9847ff6b28b2d0277cd8464eee0ef85133cdee32605c57940cacdd04a9a019079b091b6bba4cb0ec22
   languageName: node
   linkType: hard
 
@@ -786,6 +1323,20 @@ __metadata:
     object.getownpropertydescriptors: ^2.0.3
     semver: ^5.7.0
   checksum: 8c7ea6b693ca83cf5dc2d23660bfdb8bb06c2b7c0ce9226774ba9cd2d370d6977ca004577dcb9df6bd334f22ef9ab0882fb7e4e7fb0645ccd27967d7d93a62cd
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.12":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: d76d2f5edb451a3f05b15115ec89fc6be39de37c6089f1b6368df03b91e1633fd379a7e01b7ab05089a25034b2023d959b47e59759cb38d88341b2459e89d6e5
   languageName: node
   linkType: hard
 
@@ -839,7 +1390,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0":
+"once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -873,6 +1424,54 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pac-proxy-agent@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "pac-proxy-agent@npm:7.0.1"
+  dependencies:
+    "@tootallnate/quickjs-emscripten": ^0.23.0
+    agent-base: ^7.0.2
+    debug: ^4.3.4
+    get-uri: ^6.0.1
+    http-proxy-agent: ^7.0.0
+    https-proxy-agent: ^7.0.2
+    pac-resolver: ^7.0.0
+    socks-proxy-agent: ^8.0.2
+  checksum: 3d4aa48ec1c19db10158ecc1c4c9a9f77792294412d225ceb3dfa45d5a06950dca9755e2db0d9b69f12769119bea0adf2b24390d9c73c8d81df75e28245ae451
+  languageName: node
+  linkType: hard
+
+"pac-resolver@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "pac-resolver@npm:7.0.0"
+  dependencies:
+    degenerator: ^5.0.0
+    ip: ^1.1.8
+    netmask: ^2.0.2
+  checksum: fa3a898c09848e93e35f5e23443fea36ddb393a851c76a23664a5bf3fcbe58ff77a0bcdae1e4f01b9ea87ea493c52e14d97a0fe39f92474d14cd45559c6e3cde
+  languageName: node
+  linkType: hard
+
+"parent-module@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "parent-module@npm:1.0.1"
+  dependencies:
+    callsites: ^3.0.0
+  checksum: 6ba8b255145cae9470cf5551eb74be2d22281587af787a2626683a6c20fbb464978784661478dd2a3f1dad74d1e802d403e1b03c1a31fab310259eec8ac560ff
+  languageName: node
+  linkType: hard
+
+"parse-json@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "parse-json@npm:5.2.0"
+  dependencies:
+    "@babel/code-frame": ^7.0.0
+    error-ex: ^1.3.1
+    json-parse-even-better-errors: ^2.3.0
+    lines-and-columns: ^1.1.6
+  checksum: 62085b17d64da57f40f6afc2ac1f4d95def18c4323577e1eced571db75d9ab59b297d1d10582920f84b15985cbfc6b6d450ccbf317644cfa176f3ed982ad87e2
+  languageName: node
+  linkType: hard
+
 "path-exists@npm:^3.0.0":
   version: 3.0.0
   resolution: "path-exists@npm:3.0.0"
@@ -884,6 +1483,92 @@ __metadata:
   version: 1.0.1
   resolution: "path-is-absolute@npm:1.0.1"
   checksum: 060840f92cf8effa293bcc1bea81281bd7d363731d214cbe5c227df207c34cd727430f70c6037b5159c8a870b9157cba65e775446b0ab06fd5ecc7e54615a3b8
+  languageName: node
+  linkType: hard
+
+"path-type@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "path-type@npm:4.0.0"
+  checksum: 5b1e2daa247062061325b8fdbfd1fb56dde0a448fb1455453276ea18c60685bdad23a445dc148cf87bc216be1573357509b7d4060494a6fd768c7efad833ee45
+  languageName: node
+  linkType: hard
+
+"pend@npm:~1.2.0":
+  version: 1.2.0
+  resolution: "pend@npm:1.2.0"
+  checksum: 6c72f5243303d9c60bd98e6446ba7d30ae29e3d56fdb6fae8767e8ba6386f33ee284c97efe3230a0d0217e2b1723b8ab490b1bbf34fcbb2180dbc8a9de47850d
+  languageName: node
+  linkType: hard
+
+"progress@npm:2.0.3":
+  version: 2.0.3
+  resolution: "progress@npm:2.0.3"
+  checksum: f67403fe7b34912148d9252cb7481266a354bd99ce82c835f79070643bb3c6583d10dbcfda4d41e04bbc1d8437e9af0fb1e1f2135727878f5308682a579429b7
+  languageName: node
+  linkType: hard
+
+"proxy-agent@npm:6.3.1":
+  version: 6.3.1
+  resolution: "proxy-agent@npm:6.3.1"
+  dependencies:
+    agent-base: ^7.0.2
+    debug: ^4.3.4
+    http-proxy-agent: ^7.0.0
+    https-proxy-agent: ^7.0.2
+    lru-cache: ^7.14.1
+    pac-proxy-agent: ^7.0.1
+    proxy-from-env: ^1.1.0
+    socks-proxy-agent: ^8.0.2
+  checksum: 31030da419da31809340ac2521090c9a5bf4fe47a944843f829b3502883208c8586a468955e64b694140a41d70af6f45cf4793f5efd4a6f3ed94e5ac8023e36d
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "proxy-from-env@npm:1.1.0"
+  checksum: ed7fcc2ba0a33404958e34d95d18638249a68c430e30fcb6c478497d72739ba64ce9810a24f53a7d921d0c065e5b78e3822759800698167256b04659366ca4d4
+  languageName: node
+  linkType: hard
+
+"pump@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "pump@npm:3.0.0"
+  dependencies:
+    end-of-stream: ^1.1.0
+    once: ^1.3.1
+  checksum: e42e9229fba14732593a718b04cb5e1cfef8254544870997e0ecd9732b189a48e1256e4e5478148ecb47c8511dca2b09eae56b4d0aad8009e6fac8072923cfc9
+  languageName: node
+  linkType: hard
+
+"puppeteer-core@npm:21.3.6":
+  version: 21.3.6
+  resolution: "puppeteer-core@npm:21.3.6"
+  dependencies:
+    "@puppeteer/browsers": 1.7.1
+    chromium-bidi: 0.4.28
+    cross-fetch: 4.0.0
+    debug: 4.3.4
+    devtools-protocol: 0.0.1179426
+    ws: 8.14.2
+  checksum: 18f85781d0fc575fc6b5261a242414492e99ba497f914afaef9e3afd62a7ad135dbb63602cca5eae102a91ec8e84838a2bf0d6217bf68ba9b01d2c8b4152faf8
+  languageName: node
+  linkType: hard
+
+"puppeteer@npm:^21.3.5":
+  version: 21.3.6
+  resolution: "puppeteer@npm:21.3.6"
+  dependencies:
+    "@puppeteer/browsers": 1.7.1
+    cosmiconfig: 8.3.6
+    puppeteer-core: 21.3.6
+  checksum: 781dd1061e402dd14fb0d2a522987dc81624437b3cf25eae7dfde26e94a23e992e201d97c9021e002ecd3aae43e1f6a248ec70566c2520a25cd4fabe9e171506
+  languageName: node
+  linkType: hard
+
+"queue-tick@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "queue-tick@npm:1.0.1"
+  checksum: 57c3292814b297f87f792fbeb99ce982813e4e54d7a8bdff65cf53d5c084113913289d4a48ec8bbc964927a74b847554f9f4579df43c969a6c8e0f026457ad01
   languageName: node
   linkType: hard
 
@@ -909,6 +1594,13 @@ __metadata:
   version: 2.0.0
   resolution: "require-main-filename@npm:2.0.0"
   checksum: e9e294695fea08b076457e9ddff854e81bffbe248ed34c1eec348b7abbd22a0d02e8d75506559e2265e96978f3c4720bd77a6dad84755de8162b357eb6c778c7
+  languageName: node
+  linkType: hard
+
+"resolve-from@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "resolve-from@npm:4.0.0"
+  checksum: f4ba0b8494846a5066328ad33ef8ac173801a51739eb4d63408c847da9a2e1c1de1e6cbbf72699211f3d13f8fc1325648b169bd15eb7da35688e30a5fb0e4a7f
   languageName: node
   linkType: hard
 
@@ -1006,10 +1698,55 @@ __metadata:
   languageName: node
   linkType: hard
 
+"smart-buffer@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "smart-buffer@npm:4.2.0"
+  checksum: b5167a7142c1da704c0e3af85c402002b597081dd9575031a90b4f229ca5678e9a36e8a374f1814c8156a725d17008ae3bde63b92f9cfd132526379e580bec8b
+  languageName: node
+  linkType: hard
+
+"socks-proxy-agent@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "socks-proxy-agent@npm:8.0.2"
+  dependencies:
+    agent-base: ^7.0.2
+    debug: ^4.3.4
+    socks: ^2.7.1
+  checksum: 4fb165df08f1f380881dcd887b3cdfdc1aba3797c76c1e9f51d29048be6e494c5b06d68e7aea2e23df4572428f27a3ec22b3d7c75c570c5346507433899a4b6d
+  languageName: node
+  linkType: hard
+
+"socks@npm:^2.7.1":
+  version: 2.7.1
+  resolution: "socks@npm:2.7.1"
+  dependencies:
+    ip: ^2.0.0
+    smart-buffer: ^4.2.0
+  checksum: 259d9e3e8e1c9809a7f5c32238c3d4d2a36b39b83851d0f573bfde5f21c4b1288417ce1af06af1452569cd1eb0841169afd4998f0e04ba04656f6b7f0e46d748
+  languageName: node
+  linkType: hard
+
+"source-map@npm:~0.6.1":
+  version: 0.6.1
+  resolution: "source-map@npm:0.6.1"
+  checksum: 59ce8640cf3f3124f64ac289012c2b8bd377c238e316fb323ea22fbfe83da07d81e000071d7242cad7a23cd91c7de98e4df8830ec3f133cb6133a5f6e9f67bc2
+  languageName: node
+  linkType: hard
+
 "sprintf-js@npm:~1.0.2":
   version: 1.0.3
   resolution: "sprintf-js@npm:1.0.3"
   checksum: 19d79aec211f09b99ec3099b5b2ae2f6e9cdefe50bc91ac4c69144b6d3928a640bb6ae5b3def70c2e85a2c3d9f5ec2719921e3a59d3ca3ef4b2fd1a4656a0df3
+  languageName: node
+  linkType: hard
+
+"streamx@npm:^2.15.0":
+  version: 2.15.1
+  resolution: "streamx@npm:2.15.1"
+  dependencies:
+    fast-fifo: ^1.1.0
+    queue-tick: ^1.0.1
+  checksum: 6f2b4fed68caacd28efbd44d4264f5d3c2b81b0a5de14419333dac57f2075c49ae648df8d03db632a33587a6c8ab7cb9cdb4f9a2f8305be0c2cd79af35742b15
   languageName: node
   linkType: hard
 
@@ -1031,6 +1768,17 @@ __metadata:
     is-fullwidth-code-point: ^2.0.0
     strip-ansi: ^5.1.0
   checksum: 57f7ca73d201682816d573dc68bd4bb8e1dff8dc9fcf10470fdfc3474135c97175fec12ea6a159e67339b41e86963112355b64529489af6e7e70f94a7caf08b2
+  languageName: node
+  linkType: hard
+
+"string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "string-width@npm:4.2.3"
+  dependencies:
+    emoji-regex: ^8.0.0
+    is-fullwidth-code-point: ^3.0.0
+    strip-ansi: ^6.0.1
+  checksum: e52c10dc3fbfcd6c3a15f159f54a90024241d0f149cf8aed2982a2d801d2e64df0bf1dc351cf8e95c3319323f9f220c16e740b06faecd53e2462df1d2b5443fb
   languageName: node
   linkType: hard
 
@@ -1074,6 +1822,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "strip-ansi@npm:6.0.1"
+  dependencies:
+    ansi-regex: ^5.0.1
+  checksum: f3cd25890aef3ba6e1a74e20896c21a46f482e93df4a06567cebf2b57edabb15133f1f94e57434e0a958d61186087b1008e89c94875d019910a213181a14fc8c
+  languageName: node
+  linkType: hard
+
 "strip-json-comments@npm:2.0.1":
   version: 2.0.1
   resolution: "strip-json-comments@npm:2.0.1"
@@ -1099,6 +1856,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tar-fs@npm:3.0.4":
+  version: 3.0.4
+  resolution: "tar-fs@npm:3.0.4"
+  dependencies:
+    mkdirp-classic: ^0.5.2
+    pump: ^3.0.0
+    tar-stream: ^3.1.5
+  checksum: dcf4054f9e92ca0efe61c2b3f612914fb259a47900aa908a63106513a6d006c899b426ada53eb88d9dbbf089b5724c8e90b96a2c4ca6171845fa14203d734e30
+  languageName: node
+  linkType: hard
+
+"tar-stream@npm:^3.1.5":
+  version: 3.1.6
+  resolution: "tar-stream@npm:3.1.6"
+  dependencies:
+    b4a: ^1.6.4
+    fast-fifo: ^1.2.0
+    streamx: ^2.15.0
+  checksum: f3627f918581976e954ff03cb8d370551053796b82564f8c7ca8fac84c48e4d042026d0854fc222171a34ff9c682b72fae91be9c9b0a112d4c54f9e4f443e9c5
+  languageName: node
+  linkType: hard
+
+"through@npm:^2.3.8":
+  version: 2.3.8
+  resolution: "through@npm:2.3.8"
+  checksum: a38c3e059853c494af95d50c072b83f8b676a9ba2818dcc5b108ef252230735c54e0185437618596c790bbba8fcdaef5b290405981ffa09dce67b1f1bf190cbd
+  languageName: node
+  linkType: hard
+
+"tr46@npm:~0.0.3":
+  version: 0.0.3
+  resolution: "tr46@npm:0.0.3"
+  checksum: 726321c5eaf41b5002e17ffbd1fb7245999a073e8979085dacd47c4b4e8068ff5777142fc6726d6ca1fd2ff16921b48788b87225cbc57c72636f6efa8efbffe3
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.0.1":
+  version: 2.6.2
+  resolution: "tslib@npm:2.6.2"
+  checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad
+  languageName: node
+  linkType: hard
+
 "typed-array-length@npm:^1.0.4":
   version: 1.0.4
   resolution: "typed-array-length@npm:1.0.4"
@@ -1119,6 +1919,47 @@ __metadata:
     has-symbols: ^1.0.3
     which-boxed-primitive: ^1.0.2
   checksum: b7a1cf5862b5e4b5deb091672ffa579aa274f648410009c81cca63fed3b62b610c4f3b773f912ce545bb4e31edc3138975b5bc777fc6e4817dca51affb6380e9
+  languageName: node
+  linkType: hard
+
+"unbzip2-stream@npm:1.4.3":
+  version: 1.4.3
+  resolution: "unbzip2-stream@npm:1.4.3"
+  dependencies:
+    buffer: ^5.2.1
+    through: ^2.3.8
+  checksum: 0e67c4a91f4fa0fc7b4045f8b914d3498c2fc2e8c39c359977708ec85ac6d6029840e97f508675fdbdf21fcb8d276ca502043406f3682b70f075e69aae626d1d
+  languageName: node
+  linkType: hard
+
+"universalify@npm:^0.1.0":
+  version: 0.1.2
+  resolution: "universalify@npm:0.1.2"
+  checksum: 40cdc60f6e61070fe658ca36016a8f4ec216b29bf04a55dce14e3710cc84c7448538ef4dad3728d0bfe29975ccd7bfb5f414c45e7b78883567fb31b246f02dff
+  languageName: node
+  linkType: hard
+
+"urlpattern-polyfill@npm:9.0.0":
+  version: 9.0.0
+  resolution: "urlpattern-polyfill@npm:9.0.0"
+  checksum: d3658b78a10eaee514c464f5a4336c408c70cf01e9b915cb1df5892b3c49003d1ed4042dc72d1b18493b8b847883e84fbf2bf358abb5dff84b2725d5e8463bcb
+  languageName: node
+  linkType: hard
+
+"webidl-conversions@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "webidl-conversions@npm:3.0.1"
+  checksum: c92a0a6ab95314bde9c32e1d0a6dfac83b578f8fa5f21e675bc2706ed6981bc26b7eb7e6a1fab158e5ce4adf9caa4a0aee49a52505d4d13c7be545f15021b17c
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-url@npm:5.0.0"
+  dependencies:
+    tr46: ~0.0.3
+    webidl-conversions: ^3.0.0
+  checksum: b8daed4ad3356cc4899048a15b2c143a9aed0dfae1f611ebd55073310c7b910f522ad75d727346ad64203d7e6c79ef25eafd465f4d12775ca44b90fa82ed9e2c
   languageName: node
   linkType: hard
 
@@ -1187,10 +2028,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wrap-ansi@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "wrap-ansi@npm:7.0.0"
+  dependencies:
+    ansi-styles: ^4.0.0
+    string-width: ^4.1.0
+    strip-ansi: ^6.0.0
+  checksum: a790b846fd4505de962ba728a21aaeda189b8ee1c7568ca5e817d85930e06ef8d1689d49dbf0e881e8ef84436af3a88bc49115c2e2788d841ff1b8b5b51a608b
+  languageName: node
+  linkType: hard
+
 "wrappy@npm:1":
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
   checksum: 159da4805f7e84a3d003d8841557196034155008f817172d4e986bd591f74aa82aa7db55929a54222309e01079a65a92a9e6414da5a6aa4b01ee44a511ac3ee5
+  languageName: node
+  linkType: hard
+
+"ws@npm:8.14.2":
+  version: 8.14.2
+  resolution: "ws@npm:8.14.2"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 3ca0dad26e8cc6515ff392b622a1467430814c463b3368b0258e33696b1d4bed7510bc7030f7b72838b9fdeb8dbd8839cbf808367d6aae2e1d668ce741d4308b
   languageName: node
   linkType: hard
 
@@ -1201,6 +2068,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"y18n@npm:^5.0.5":
+  version: 5.0.8
+  resolution: "y18n@npm:5.0.8"
+  checksum: 54f0fb95621ee60898a38c572c515659e51cc9d9f787fb109cef6fde4befbe1c4602dc999d30110feee37456ad0f1660fa2edcfde6a9a740f86a290999550d30
+  languageName: node
+  linkType: hard
+
 "yargs-parser@npm:13.1.2, yargs-parser@npm:^13.1.2":
   version: 13.1.2
   resolution: "yargs-parser@npm:13.1.2"
@@ -1208,6 +2082,13 @@ __metadata:
     camelcase: ^5.0.0
     decamelize: ^1.2.0
   checksum: c8bb6f44d39a4acd94462e96d4e85469df865de6f4326e0ab1ac23ae4a835e5dd2ddfe588317ebf80c3a7e37e741bd5cb0dc8d92bcc5812baefb7df7c885e86b
+  languageName: node
+  linkType: hard
+
+"yargs-parser@npm:^21.1.1":
+  version: 21.1.1
+  resolution: "yargs-parser@npm:21.1.1"
+  checksum: ed2d96a616a9e3e1cc7d204c62ecc61f7aaab633dcbfab2c6df50f7f87b393993fe6640d017759fe112d0cb1e0119f2b4150a87305cc873fd90831c6a58ccf1c
   languageName: node
   linkType: hard
 
@@ -1237,5 +2118,30 @@ __metadata:
     y18n: ^4.0.0
     yargs-parser: ^13.1.2
   checksum: 75c13e837eb2bb25717957ba58d277e864efc0cca7f945c98bdf6477e6ec2f9be6afa9ed8a876b251a21423500c148d7b91e88dee7adea6029bdec97af1ef3e8
+  languageName: node
+  linkType: hard
+
+"yargs@npm:17.7.1":
+  version: 17.7.1
+  resolution: "yargs@npm:17.7.1"
+  dependencies:
+    cliui: ^8.0.1
+    escalade: ^3.1.1
+    get-caller-file: ^2.0.5
+    require-directory: ^2.1.1
+    string-width: ^4.2.3
+    y18n: ^5.0.5
+    yargs-parser: ^21.1.1
+  checksum: 3d8a43c336a4942bc68080768664aca85c7bd406f018bad362fd255c41c8f4e650277f42fd65d543fce99e084124ddafee7bbfc1a5c6a8fda4cec78609dcf8d4
+  languageName: node
+  linkType: hard
+
+"yauzl@npm:^2.10.0":
+  version: 2.10.0
+  resolution: "yauzl@npm:2.10.0"
+  dependencies:
+    buffer-crc32: ~0.2.3
+    fd-slicer: ~1.1.0
+  checksum: 7f21fe0bbad6e2cb130044a5d1d0d5a0e5bf3d8d4f8c4e6ee12163ce798fee3de7388d22a7a0907f563ac5f9d40f8699a223d3d5c1718da90b0156da6904022b
   languageName: node
   linkType: hard


### PR DESCRIPTION
This commit updates the logic to espace unsafe patterns:

- for elements that can have raw text: all matching closing tags are escaped
- for comment nodes: all closing comment tags are escaped
- for processing instructions: all `>` symbols are escaped