### PR TITLE
fix: escape angel brackets in attribute value

### DIFF
--- a/lib/HTMLParser.js
+++ b/lib/HTMLParser.js
@@ -2165,9 +2165,6 @@ function HTMLParser(address, fragmentContext, options) {
       case "plaintext":
         tokenizer = plaintext_state;
         break;
-      case "noscript":
-        if (scripting_enabled)
-          tokenizer = plaintext_state;
       }
     }
 
@@ -5932,13 +5929,6 @@ function HTMLParser(address, fragmentContext, options) {
       case "noembed":
         parseRawText(value,arg3);
         return;
-
-      case "noscript":
-        if (scripting_enabled) {
-          parseRawText(value,arg3);
-          return;
-        }
-        break;  // XXX Otherwise treat it as any other open tag?
 
       case "select":
         afereconstruct();

--- a/lib/NodeUtils.js
+++ b/lib/NodeUtils.js
@@ -55,31 +55,49 @@ var extraNewLine = {
   */
 };
 
+const ESCAPE_REGEXP = /[&<>\u00A0]/g;
+const ESCAPE_ATTR_REGEXP = /[&"<>\u00A0]/g;
+
 function escape(s) {
-  return s.replace(/[&<>\u00A0]/g, function(c) {
-    switch(c) {
-    case '&': return '&amp;';
-    case '<': return '&lt;';
-    case '>': return '&gt;';
-    case '\u00A0': return '&nbsp;';
+  if (!ESCAPE_REGEXP.test(s)) {
+    // nothing to do, fast path
+    return s;
+  }
+
+  return s.replace(ESCAPE_REGEXP, (c) => {
+    switch (c) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case "\u00A0":
+        return "&nbsp;";
     }
   });
 }
 
 function escapeAttr(s) {
-  var toEscape = /[&"\u00A0]/g;
-  if (!toEscape.test(s)) {
-      // nothing to do, fast path
-      return s;
-  } else {
-      return s.replace(toEscape, function(c) {
-        switch(c) {
-        case '&': return '&amp;';
-        case '"': return '&quot;';
-        case '\u00A0': return '&nbsp;';
-        }
-      });
+  if (!ESCAPE_ATTR_REGEXP.test(s)) {
+    // nothing to do, fast path
+    return s;
   }
+
+  return s.replace(ESCAPE_ATTR_REGEXP, (c) => {
+    switch (c) {
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case "&":
+        return "&amp;";
+      case '"':
+        return "&quot;";
+      case "\u00A0":
+        return "&nbsp;";
+    }
+  });
 }
 
 function attrname(a) {

--- a/test/domino.js
+++ b/test/domino.js
@@ -399,7 +399,7 @@ exports.outerHTML = function() {
     // see https://github.com/whatwg/html/issues/944
     //'<body><pre>\n\na\n</pre></body>',
     '<body bgcolor="white"><h1 style="color: red">\nOne\n2 &amp; 3</h1></body>',
-    '<body data-test="<>&amp;&quot;\'"></body>'
+    `<body data-test="&lt;&gt;&amp;&quot;\'"></body>`
   ];
   tests.forEach(function(html) {
     var d = domino.createDocument(html);

--- a/test/domino.js
+++ b/test/domino.js
@@ -1492,3 +1492,9 @@ exports.supportsNonceAttribute = function() {
   h1.nonce = 'randomhaash';
   h1.outerHTML.should.equal('<style nonce="randomhaash">* {color: red}</style>');
 };
+
+exports.supportsHtmlElementsInNoScriptTag = function() {
+  const document = domino.createDocument('<body><noscript>For information <em>click</em> here.</noscript></body>');
+  const noscript = document.querySelector('noscript');
+  noscript.outerHTML.should.equal('<noscript>For information <em>click</em> here.</noscript>');
+};

--- a/test/html5lib-tests.json
+++ b/test/html5lib-tests.json
@@ -8319,7 +8319,7 @@
             ]
           }
         ],
-        "html": "<html><head></head><body><div bar=\"ZZ>YY\"></div></body></html>",
+        "html": "<html><head></head><body><div bar=\"ZZ&gt;YY\"></div></body></html>",
         "noQuirksBodyHtml": "<div bar=\"ZZ>YY\"></div>"
       }
     },
@@ -8715,7 +8715,7 @@
             ]
           }
         ],
-        "html": "<html><head></head><body><div bar=\"ZZ> YY\"></div></body></html>",
+        "html": "<html><head></head><body><div bar=\"ZZ&gt; YY\"></div></body></html>",
         "noQuirksBodyHtml": "<div bar=\"ZZ> YY\"></div>"
       }
     },
@@ -8758,7 +8758,7 @@
             ]
           }
         ],
-        "html": "<html><head></head><body><div bar=\"ZZ>\"></div></body></html>",
+        "html": "<html><head></head><body><div bar=\"ZZ&gt;\"></div></body></html>",
         "noQuirksBodyHtml": "<div bar=\"ZZ>\"></div>"
       }
     },
@@ -8801,7 +8801,7 @@
             ]
           }
         ],
-        "html": "<html><head></head><body><div bar=\"ZZ>\"></div></body></html>",
+        "html": "<html><head></head><body><div bar=\"ZZ&gt;\"></div></body></html>",
         "noQuirksBodyHtml": "<div bar=\"ZZ>\"></div>"
       }
     },
@@ -8844,7 +8844,7 @@
             ]
           }
         ],
-        "html": "<html><head></head><body><div bar=\"ZZ>\"></div></body></html>",
+        "html": "<html><head></head><body><div bar=\"ZZ&gt;\"></div></body></html>",
         "noQuirksBodyHtml": "<div bar=\"ZZ>\"></div>"
       }
     },

--- a/test/xss.js
+++ b/test/xss.js
@@ -83,3 +83,14 @@ exports.fp170_37 = function() {
     '<p><svg><style>*{font-family:\'&lt;/style&gt;&lt;img/src=x\tonerror=xss()//\'}</style></svg></p>'
   );
 };
+
+exports.escapeAngleBracketsInDivAttr = function() {
+  var document = domino.createDocument(
+    `<div>You don't have JS! Click<a href="#" title="Search for </div><script>alert(1)</script> without JS">here</a> to go to the no-js website.</div>`
+  );
+  // Ensure that HTML entities are properly encoded inside <style>
+  document.body.innerHTML.should.equal(
+    `<div>You don't have JS! Click<a href="#" title="Search for &lt;/div&gt;&lt;script&gt;alert(1)&lt;/script&gt; without JS">here</a> to go to the no-js website.</div>`
+  );
+};
+

--- a/test/xss.js
+++ b/test/xss.js
@@ -88,9 +88,17 @@ exports.escapeAngleBracketsInDivAttr = function() {
   var document = domino.createDocument(
     `<div>You don't have JS! Click<a href="#" title="Search for </div><script>alert(1)</script> without JS">here</a> to go to the no-js website.</div>`
   );
-  // Ensure that HTML entities are properly encoded inside <style>
   document.body.innerHTML.should.equal(
     `<div>You don't have JS! Click<a href="#" title="Search for &lt;/div&gt;&lt;script&gt;alert(1)&lt;/script&gt; without JS">here</a> to go to the no-js website.</div>`
+  );
+};
+
+exports.escapeAngleBracketsInNoScriptAttr = function() {
+  var document = domino.createDocument(
+    `<div><noscript>You don't have JS! Click<a href="#" title="Search for </noscript><script>alert(1)</script> without JS">here</a> to go to the no-js website.</noscript></div>`
+  );
+  document.body.innerHTML.should.equal(
+    `<div><noscript>You don't have JS! Click<a href="#" title="Search for &lt;/noscript&gt;&lt;script&gt;alert(1)&lt;/script&gt; without JS">here</a> to go to the no-js website.</noscript></div>`
   );
 };
 


### PR DESCRIPTION
**fix: santize noscript contents**
    
Previously, `noscript` was parsed as raw text. This however is not correct as `noscript` can contain child elements. We no updated the logic to parse noscript as an element which causes santization of child nodes.



**fix: escape angle brackets in attribute value**
    
Angle brackets inside attribute values are now escaped, This is to ensure unsafe behaviour after de-serialization.