### PR TITLE
fix: Escapes in raw text 

### DIFF
--- a/lib/NodeUtils.js
+++ b/lib/NodeUtils.js
@@ -137,12 +137,15 @@ function escapeMatchingClosingTag(rawText, parentTag) {
   if (!rawText.toLowerCase().includes(parentClosingTag)) {
     return rawText; // fast path
   }
-  const result = [...rawText];
-  const matches = rawText.matchAll(new RegExp(parentClosingTag, 'ig'));
-  for (const match of matches) {
-    result[match.index] = '&lt;';
-  }
-  return result.join('');
+  // Replace via String.prototype.replace so we don't have to reconcile
+  // UTF-16 code-unit offsets (match.index) with code-point indexing
+  // (`[...rawText]`). Astral characters (e.g. emoji) before the match
+  // would otherwise shift the replacement and leave a real `</tag>`
+  // break-out in the output.
+  return rawText.replace(
+    new RegExp(parentClosingTag, 'ig'),
+    (m) => '&lt;' + m.slice(1)
+  );
 }
 
 const CLOSING_COMMENT_REGEXP = /--!?>/;

--- a/lib/NodeUtils.js
+++ b/lib/NodeUtils.js
@@ -191,7 +191,9 @@ function serializeOne(kid, parent) {
         var ss = kid.serialize();
         // If an element can have raw content, this content may
         // potentially require escaping to avoid XSS.
-        if (hasRawContent[tagname.toUpperCase()]) {
+        var upperTag = tagname.toUpperCase();
+        if (hasRawContent[upperTag] ||
+            (upperTag === 'NOSCRIPT' && kid.ownerDocument._scripting_enabled)) {
           ss = escapeMatchingClosingTag(ss, tagname);
         }
         if (html && extraNewLine[tagname] && ss.charAt(0)==='\n') s += '\n';

--- a/lib/NodeUtils.js
+++ b/lib/NodeUtils.js
@@ -29,6 +29,7 @@ var hasRawContent = {
   XMP: true,
   IFRAME: true,
   NOEMBED: true,
+  NOSCRIPT: true,
   NOFRAMES: true,
   PLAINTEXT: true
 };
@@ -195,8 +196,7 @@ function serializeOne(kid, parent) {
         // If an element can have raw content, this content may
         // potentially require escaping to avoid XSS.
         var upperTag = tagname.toUpperCase();
-        if (hasRawContent[upperTag] ||
-            (upperTag === 'NOSCRIPT' && kid.ownerDocument._scripting_enabled)) {
+        if (hasRawContent[upperTag]) {
           ss = escapeMatchingClosingTag(ss, tagname);
         }
         if (html && extraNewLine[tagname] && ss.charAt(0)==='\n') s += '\n';
@@ -214,8 +214,7 @@ function serializeOne(kid, parent) {
       else
         parenttag = '';
 
-      if (hasRawContent[parenttag] ||
-          (parenttag==='NOSCRIPT' && parent.ownerDocument._scripting_enabled)) {
+      if (hasRawContent[parenttag]) {
         s += kid.data;
       } else {
         s += escape(kid.data);

--- a/test/xss.js
+++ b/test/xss.js
@@ -180,13 +180,11 @@ exports.styleMatchingClosingTagSkipsUnclosedCommentedContent = function () {
 };
 
 exports.noscriptMatchingClosingTagInRawText = function () {
-  // Use a parsed document so `_scripting_enabled` is true, matching how
-  // Angular SSR / platform-server uses domino. With scripting enabled,
   // <noscript> is a raw-text element on serialization and its text data
   // must have any `</noscript` closing-tag prefix escaped, otherwise an
   // attacker-controlled text payload can break out and inject a live
   // <script> sibling in the receiving browser.
-  const document = domino.createDocument('<!doctype html><html><body></body></html>');
+  const document = domino.createDocument('');
   const noscript = document.createElement('noscript');
   noscript.textContent = 'abc</noscript><script>alert(1)</script>';
   document.body.appendChild(noscript);

--- a/test/xss.js
+++ b/test/xss.js
@@ -199,6 +199,21 @@ exports.noscriptMatchingClosingTagInRawText = function () {
   return alertFired(html).should.eventually.be.false('alert fired for: ' + html);
 };
 
+exports.iframeMatchingClosingTagWithAstralPrefix = function () {
+  // Astral characters (e.g. emoji) before a `</iframe>` inside iframe text
+  // content must still trigger the closing-tag escape, otherwise the
+  // payload breaks out and a sibling <script> executes in the browser.
+  const document = domino.createDocument('<!doctype html><html><body><iframe></iframe></body></html>');
+  const iframe = document.getElementsByTagName('iframe')[0];
+  iframe.textContent =
+    '\uD83D\uDE00'.repeat(20) +
+    "</iframe><script>/*AAAAAAAAAAAAAAAAAAAAAAAAAAAA*/alert(1)</script>";
+
+  const html = document.serialize();
+  html.should.not.match(/<\/iframe><script>/);
+  return alertFired(html).should.eventually.be.false('alert fired for: ' + html);
+};
+
 exports.scriptMatchingClosingTagInRawText = function () {
   const document = domino.createDocument('');
   const script = document.createElement('script');
@@ -335,6 +350,20 @@ exports.verifyEscapeMatchingClosingTag = function () {
       '<xmp></style><script>alert(1)</script></xmp>',
       'iframe',
       '<xmp></style><script>alert(1)</script></xmp>',
+    ],
+
+    // Astral (non-BMP) characters before the closing tag must not shift
+    // the position of the escape: regex `match.index` is a UTF-16 code-unit
+    // offset while a code-point array would be off by one per astral char.
+    [
+      '\uD83D\uDE00'.repeat(20) + '</iframe><script>alert(1)</script>',
+      'iframe',
+      '\uD83D\uDE00'.repeat(20) + '&lt;/iframe><script>alert(1)</script>',
+    ],
+    [
+      '\uD83D\uDE00</style><script>alert(1)</script>',
+      'style',
+      '\uD83D\uDE00&lt;/style><script>alert(1)</script>',
     ],
   ];
   for (const [rawContent, parentTag, expected] of cases) {

--- a/test/xss.js
+++ b/test/xss.js
@@ -179,6 +179,26 @@ exports.styleMatchingClosingTagSkipsUnclosedCommentedContent = function () {
   return alertFired(html).should.eventually.be.false('alert fired for: ' + html);
 };
 
+exports.noscriptMatchingClosingTagInRawText = function () {
+  // Use a parsed document so `_scripting_enabled` is true, matching how
+  // Angular SSR / platform-server uses domino. With scripting enabled,
+  // <noscript> is a raw-text element on serialization and its text data
+  // must have any `</noscript` closing-tag prefix escaped, otherwise an
+  // attacker-controlled text payload can break out and inject a live
+  // <script> sibling in the receiving browser.
+  const document = domino.createDocument('<!doctype html><html><body></body></html>');
+  const noscript = document.createElement('noscript');
+  noscript.textContent = 'abc</noscript><script>alert(1)</script>';
+  document.body.appendChild(noscript);
+
+  document.body
+    .serialize()
+    .should.equal('<noscript>abc&lt;/noscript><script>alert(1)</script></noscript>');
+
+  const html = document.serialize();
+  return alertFired(html).should.eventually.be.false('alert fired for: ' + html);
+};
+
 exports.scriptMatchingClosingTagInRawText = function () {
   const document = domino.createDocument('');
   const script = document.createElement('script');


### PR DESCRIPTION
### fix: Escapes </noscript in raw text when scripting enabled
Ensuring raw text within `<noscript>` elements is properly escaped during serialization if scripting is enabled. Adds a test to verify controlled payloads cannot break out of `<noscript>` and inject scripts.

Fixes https://github.com/angular/angular/issues/68903

### fix: fix raw-text element serialization

Correct raw-text closing-tag escaping so astral Unicode characters cannot
misalign the escaped `<` character. This prevents serialized raw-text content
from breaking out into executable markup such as `</iframe><script>`.