### PR TITLE
build: remove engine constraints from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,6 @@
   "description": "Server-side DOM implementation based on Mozilla's dom.js",
   "main": "./lib",
   "packageManager": "pnpm@10.31.0",
-  "engines": {
-    "npm": "Please use pnpm instead of NPM to install dependencies",
-    "yarn": "Please use pnpm instead of Yarn to install dependencies",
-    "pnpm": "10.31.0"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/domino.git"


### PR DESCRIPTION
Required as the installations fail in Angular LTS branch 
```
error domino@2.1.6: The engine "yarn" is incompatible with this module. Expected version "Please use pnpm instead of Yarn to install dependencies". Got "1.22.22"
```