### PR TITLE
fix: Normalizes SVG `attributeName` attribute case

### DIFF
--- a/lib/Element.js
+++ b/lib/Element.js
@@ -591,6 +591,11 @@ Element.prototype = Object.create(ContainerNode.prototype, {
 
   // Set the attribute without error checking. The parser uses this.
   _setAttribute: { value: function _setAttribute(qname, value) {
+    if (this.namespaceURI === NAMESPACE.SVG) {
+      if (utils.toASCIILowerCase(qname) === 'attributename') {
+        qname = 'attributeName';
+      }
+    }
     // XXX: the spec says that this next search should be done
     // on the local name, but I think that is an error.
     // email pending on www-dom about it.

--- a/test/domino.js
+++ b/test/domino.js
@@ -987,6 +987,23 @@ exports.createSvgElements = function() {
   document.body.innerHTML.should.equal("<svg></svg>");
 };
 
+exports.svgAttributeNameAdjustmentsFromSetAttribute = function() {
+  var document = domino.createDocument();
+  var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  var set = document.createElementNS("http://www.w3.org/2000/svg", "set");
+
+  set.setAttribute("attributename", "href");
+  set.setAttribute("to", "javascript:alert(1)");
+  svg.appendChild(set);
+  document.body.appendChild(svg);
+
+  set.getAttribute("attributeName").should.equal("href");
+  (set.getAttribute("attributename") === null).should.be.true();
+  document.body.innerHTML.should.equal(
+    '<svg><set attributeName="href" to="javascript:alert(1)"></set></svg>'
+  );
+};
+
 exports.gh95 = function() {
     var document = domino.createDocument(
         '<body><a href="foo\'s">bar</a></body>'


### PR DESCRIPTION
Corrects the casing of the `attributeName` attribute for SVG elements. The SVG DOM typically expects `attributeName` to be camelCase. This change normalizes `attributename` (lowercase) to `attributeName` when calling `setAttribute` on SVG elements, ensuring consistent and spec-compliant behavior.

Includes a new test to validate this attribute name adjustment and its retrieval.


Fixed issue in https://github.com/angular/angular/pull/69161