### PR TITLE
fix: escape fallback raw-content text nodes

### DIFF
--- a/lib/NodeUtils.js
+++ b/lib/NodeUtils.js
@@ -34,6 +34,15 @@ var hasRawContent = {
   PLAINTEXT: true
 };
 
+var hasRawContentFallback = {
+  // Text in these fallback raw-content elements is inert for browser parsing,
+  // but downstream SSR post-processing may reparse it without raw-text state.
+  IFRAME: true,
+  NOEMBED: true,
+  NOSCRIPT: true,
+  NOFRAMES: true
+};
+
 var emptyElements = {
   area: true,
   base: true,
@@ -134,7 +143,7 @@ function attrname(a) {
  * and unsafe behavior after de-serialization.
  */
 function escapeMatchingClosingTag(rawText, parentTag) {
-  const parentClosingTag = '</' + parentTag;
+  const parentClosingTag = ('</' + parentTag).toLowerCase();
   if (!rawText.toLowerCase().includes(parentClosingTag)) {
     return rawText; // fast path
   }
@@ -144,9 +153,51 @@ function escapeMatchingClosingTag(rawText, parentTag) {
   // would otherwise shift the replacement and leave a real `</tag>`
   // break-out in the output.
   return rawText.replace(
-    new RegExp(parentClosingTag, 'ig'),
+    new RegExp(escapeRegExp(parentClosingTag), 'ig'),
     (m) => '&lt;' + m.slice(1)
   );
+}
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function escapeFallbackRawText(rawText, parentTag) {
+  var result = '';
+  var index = 0;
+
+  while (index < rawText.length) {
+    var commentStart = rawText.indexOf('<!--', index);
+    if (commentStart === -1) {
+      result += escape(rawText.slice(index));
+      break;
+    }
+
+    result += escape(rawText.slice(index, commentStart));
+
+    var commentEnd = findCommentEnd(rawText, commentStart + 4);
+    if (commentEnd === -1) {
+      result += escapeMatchingClosingTag(rawText.slice(commentStart), parentTag);
+      break;
+    }
+
+    // A complete HTML comment remains inert if downstream tooling reparses
+    // fallback raw text as normal HTML, so preserve its comment semantics.
+    result += escapeMatchingClosingTag(rawText.slice(commentStart, commentEnd), parentTag);
+    index = commentEnd;
+  }
+
+  return result;
+}
+
+function findCommentEnd(rawText, index) {
+  if (rawText.charAt(index) === '>')
+    return index + 1;
+  if (rawText.charAt(index) === '-' && rawText.charAt(index + 1) === '>')
+    return index + 2;
+
+  var match = CLOSING_COMMENT_REGEXP.exec(rawText.slice(index));
+  return match ? index + match.index + match[0].length : -1;
 }
 
 const CLOSING_COMMENT_REGEXP = /--!?>/;
@@ -196,7 +247,7 @@ function serializeOne(kid, parent) {
         // If an element can have raw content, this content may
         // potentially require escaping to avoid XSS.
         var upperTag = tagname.toUpperCase();
-        if (hasRawContent[upperTag]) {
+        if (hasRawContent[upperTag] && !hasRawContentFallback[upperTag]) {
           ss = escapeMatchingClosingTag(ss, tagname);
         }
         if (html && extraNewLine[tagname] && ss.charAt(0)==='\n') s += '\n';
@@ -215,7 +266,9 @@ function serializeOne(kid, parent) {
         parenttag = '';
 
       if (hasRawContent[parenttag]) {
-        s += kid.data;
+        // Preserve actual child element markup in fallback elements such as
+        // <noscript>, but do not emit text-node payloads as raw HTML.
+        s += hasRawContentFallback[parenttag] ? escapeFallbackRawText(kid.data, parent.localName) : kid.data;
       } else {
         s += escape(kid.data);
       }

--- a/test/html5lib-tests.json
+++ b/test/html5lib-tests.json
@@ -14216,8 +14216,8 @@
             ]
           }
         ],
-        "html": "<html><head><noscript><noframes>XXX</noscript></noframes></noscript></head><body></body></html>",
-        "noQuirksBodyHtml": "<noscript><noframes>XXX</noscript></noframes></noscript>"
+        "html": "<html><head><noscript><noframes>XXX&lt;/noscript&gt;</noframes></noscript></head><body></body></html>",
+        "noQuirksBodyHtml": "<noscript><noframes>XXX&lt;/noscript&gt;</noframes></noscript>"
       }
     },
     {
@@ -39310,8 +39310,8 @@
             ]
           }
         ],
-        "html": "<html><head></head><frameset><frame><frameset><frame></frameset><noframes></frameset><noframes></noframes></frameset></html>",
-        "noQuirksBodyHtml": "<noframes></frameset><noframes></noframes>"
+        "html": "<html><head></head><frameset><frame><frameset><frame></frameset><noframes>&lt;/frameset&gt;&lt;noframes&gt;</noframes></frameset></html>",
+        "noQuirksBodyHtml": "<noframes>&lt;/frameset&gt;&lt;noframes&gt;</noframes>"
       }
     },
     {
@@ -43467,7 +43467,7 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><noscript><!--</noscript></head><body>X<noscript>--></noscript></body></html>",
+        "html": "<!DOCTYPE html><html><head><noscript><!--</noscript></head><body>X<noscript>--&gt;</noscript></body></html>",
         "noQuirksBodyHtml": "<noscript><!--</noscript>X<noscript>--></noscript>"
       }
     },
@@ -43563,8 +43563,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><noscript><iframe></noscript></head><body>X</body></html>",
-        "noQuirksBodyHtml": "<noscript><iframe></noscript>X</iframe></noscript>"
+        "html": "<!DOCTYPE html><html><head><noscript>&lt;iframe&gt;</noscript></head><body>X</body></html>",
+        "noQuirksBodyHtml": "<noscript><iframe>&lt;/noscript&gt;X</iframe></noscript>"
       }
     },
     {
@@ -43618,8 +43618,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><noscript></noscript></head><body><iframe></noscript>X</iframe></body></html>",
-        "noQuirksBodyHtml": "<noscript><iframe></noscript>X</iframe></noscript>"
+        "html": "<!DOCTYPE html><html><head><noscript></noscript></head><body><iframe>&lt;/noscript&gt;X</iframe></body></html>",
+        "noQuirksBodyHtml": "<noscript><iframe>&lt;/noscript&gt;X</iframe></noscript>"
       }
     },
     {
@@ -43717,8 +43717,8 @@
             ]
           }
         ],
-        "html": "<!DOCTYPE html><html><head><noframes><body><script><!--...</script></body></noframes></head><body></body></html>",
-        "noQuirksBodyHtml": "<noframes><body><script><!--...</script></body></noframes>"
+        "html": "<!DOCTYPE html><html><head><noframes>&lt;body&gt;&lt;script&gt;<!--...</script></body></noframes></head><body></body></html>",
+        "noQuirksBodyHtml": "<noframes>&lt;body&gt;&lt;script&gt;<!--...</script></body></noframes>"
       }
     },
     {
@@ -47887,7 +47887,7 @@
             ]
           }
         ],
-        "html": "<html><head><noscript><!--</noscript></head><body>X<noscript>--></noscript></body></html>",
+        "html": "<html><head><noscript><!--</noscript></head><body>X<noscript>--&gt;</noscript></body></html>",
         "noQuirksBodyHtml": "<noscript><!--</noscript>X<noscript>--></noscript>"
       }
     },
@@ -47979,8 +47979,8 @@
             ]
           }
         ],
-        "html": "<html><head><noscript><iframe></noscript></head><body>X</body></html>",
-        "noQuirksBodyHtml": "<noscript><iframe></noscript>X</iframe></noscript>"
+        "html": "<html><head><noscript>&lt;iframe&gt;</noscript></head><body>X</body></html>",
+        "noQuirksBodyHtml": "<noscript><iframe>&lt;/noscript&gt;X</iframe></noscript>"
       }
     },
     {
@@ -48031,8 +48031,8 @@
             ]
           }
         ],
-        "html": "<html><head><noscript></noscript></head><body><iframe></noscript>X</iframe></body></html>",
-        "noQuirksBodyHtml": "<noscript><iframe></noscript>X</iframe></noscript>"
+        "html": "<html><head><noscript></noscript></head><body><iframe>&lt;/noscript&gt;X</iframe></body></html>",
+        "noQuirksBodyHtml": "<noscript><iframe>&lt;/noscript&gt;X</iframe></noscript>"
       }
     },
     {
@@ -48125,8 +48125,8 @@
             ]
           }
         ],
-        "html": "<html><head><noframes><body><script><!--...</script></body></noframes></head><body></body></html>",
-        "noQuirksBodyHtml": "<noframes><body><script><!--...</script></body></noframes>"
+        "html": "<html><head><noframes>&lt;body&gt;&lt;script&gt;<!--...</script></body></noframes></head><body></body></html>",
+        "noQuirksBodyHtml": "<noframes>&lt;body&gt;&lt;script&gt;<!--...</script></body></noframes>"
       }
     },
     {

--- a/test/tools/update-html5lib-tests.js
+++ b/test/tools/update-html5lib-tests.js
@@ -51,6 +51,12 @@ var NO_ESCAPE = {
   noframes:true, plaintext:true,
   noscript: true // <- assumes that scripting is enabled.
 };
+var NO_ESCAPE_FALLBACK = {
+  iframe: true,
+  noembed: true,
+  noframes: true,
+  noscript: true
+};
 
 var localname = function(namestring) {
   return namestring.replace(/^(svg|math|xlink|xml|xmlns) /, '');
@@ -117,6 +123,7 @@ var serialize_doc = function(filename, fragment, doc) {
   var clear_add_attr = function() {
     if (can_add_attr) {
       result += '>';
+      stack_top().contentStart = result.length;
       can_add_attr = false;
     }
   };
@@ -130,10 +137,18 @@ var serialize_doc = function(filename, fragment, doc) {
                                filename, doc);
         }
       } else {
+        if (old.ns === namespace('html') &&
+            NO_ESCAPE[old.tag] &&
+            !NO_ESCAPE_FALLBACK[old.tag] &&
+            old.contentStart !== undefined) {
+          result = result.slice(0, old.contentStart) +
+              escapeMatchingClosingTag(result.slice(old.contentStart), old.tag);
+        }
         result += '</' + old.tag + '>';
       }
     }
     // save some space in the JSON output by omitting empty lists
+    old.contentStart = undefined;
     if (old.children.length===0) { old.children = undefined; }
     if (old.attrs && old.attrs.length===0) { old.attrs = undefined; }
     return old;
@@ -160,6 +175,54 @@ var serialize_doc = function(filename, fragment, doc) {
       case '\u00A0': return '&nbsp;';
       }
     });
+  };
+  var escapeRegExp = function(s) {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  };
+  var escapeMatchingClosingTag = function(s, parentTag) {
+    var parentClosingTag = ('</' + parentTag).toLowerCase();
+    if (!s.toLowerCase().includes(parentClosingTag)) {
+      return s;
+    }
+    return s.replace(
+        new RegExp(escapeRegExp(parentClosingTag), 'ig'),
+        function(m) { return '&lt;' + m.slice(1); });
+  };
+  var findCommentEnd = function(s, index) {
+    if (s.charAt(index) === '>') {
+      return index + 1;
+    }
+    if (s.charAt(index) === '-' && s.charAt(index + 1) === '>') {
+      return index + 2;
+    }
+
+    var match = /--!?>/.exec(s.slice(index));
+    return match ? index + match.index + match[0].length : -1;
+  };
+  var escapeFallbackRawText = function(s, parentTag) {
+    var result = '';
+    var index = 0;
+
+    while (index < s.length) {
+      var commentStart = s.indexOf('<!--', index);
+      if (commentStart === -1) {
+        result += escape(s.slice(index));
+        break;
+      }
+
+      result += escape(s.slice(index, commentStart));
+
+      var commentEnd = findCommentEnd(s, commentStart + 4);
+      if (commentEnd === -1) {
+        result += escapeMatchingClosingTag(s.slice(commentStart), parentTag);
+        break;
+      }
+
+      result += escapeMatchingClosingTag(s.slice(commentStart, commentEnd), parentTag);
+      index = commentEnd;
+    }
+
+    return result;
   };
 
   while (doc.length > 0) {
@@ -246,7 +309,9 @@ var serialize_doc = function(filename, fragment, doc) {
       if (text !== escape(text) && !obj.no_escape) {
         obj.escaped = props.escaped = true;
       }
-      result += obj.no_escape ? text : escape(text);
+      result += obj.no_escape
+        ? (NO_ESCAPE_FALLBACK[stack_top().tag] ? escapeFallbackRawText(text, stack_top().tag) : text)
+        : escape(text);
       stack_top().children.push(obj);
       continue;
     }
@@ -330,6 +395,13 @@ var twiddle_test = function(filename, tc) {
   if (filename==='webkit01' &&
       /<rdar: 6869687="" problem="">/.test(expected)) {
     expected = expected.replace(/(6869687=[^> ]+) (problem=[^> ]+)/g, '$2 $1');
+  }
+  if (filename==='webkit02' &&
+      tc.script==='on' &&
+      /<p id="status"><noscript><strong>A<\/strong><\/noscript><span>B<\/span><\/p>/.test(tc.data)) {
+    expected = expected.replace(
+        '<noscript>&lt;strong&gt;A&lt;/strong&gt;</noscript>',
+        '<noscript><strong>A</strong></noscript>');
   }
   tc.document.html = expected;
   // Will this pass if parsed as a <body> fragment in no-quirks mode?

--- a/test/xss.js
+++ b/test/xss.js
@@ -191,7 +191,7 @@ exports.noscriptMatchingClosingTagInRawText = function () {
 
   document.body
     .serialize()
-    .should.equal('<noscript>abc&lt;/noscript><script>alert(1)</script></noscript>');
+    .should.equal('<noscript>abc&lt;/noscript&gt;&lt;script&gt;alert(1)&lt;/script&gt;</noscript>');
 
   const html = document.serialize();
   return alertFired(html).should.eventually.be.false('alert fired for: ' + html);
@@ -210,6 +210,193 @@ exports.iframeMatchingClosingTagWithAstralPrefix = function () {
   const html = document.serialize();
   html.should.not.match(/<\/iframe><script>/);
   return alertFired(html).should.eventually.be.false('alert fired for: ' + html);
+};
+
+exports.iframeAncestorClosingTagEscaped = function () {
+  const document = domino.createDocument('');
+  const section = document.createElement('section');
+  const iframe = document.createElement('iframe');
+  iframe.textContent = '</section><script>alert("iframe_ancestor_close")//</script><section>';
+  section.appendChild(iframe);
+  document.body.appendChild(section);
+
+  document.body
+    .serialize()
+    .should.equal(
+      '<section><iframe>&lt;/section&gt;&lt;script&gt;alert("iframe_ancestor_close")//&lt;/script&gt;&lt;section&gt;</iframe></section>',
+    );
+
+  const reparsed = domino.createDocument('<body>' + iframe.serialize() + '</body>').body.innerHTML;
+  reparsed.should.not.containEql('<script>');
+  return alertFired(reparsed).should.eventually.be.false('alert fired after normal HTML reparse for: ' + reparsed);
+};
+
+exports.noscriptAncestorClosingTagEscaped = function () {
+  const document = domino.createDocument('');
+  const div = document.createElement('div');
+  const noscript = document.createElement('noscript');
+  noscript.textContent = '</div><script>alert("noscript_ancestor_close")//</script><div>';
+  div.appendChild(noscript);
+  document.body.appendChild(div);
+
+  document.body
+    .serialize()
+    .should.equal(
+      '<div><noscript>&lt;/div&gt;&lt;script&gt;alert("noscript_ancestor_close")//&lt;/script&gt;&lt;div&gt;</noscript></div>',
+    );
+
+  const reparsed = domino.createDocument('<body>' + noscript.serialize() + '</body>').body.innerHTML;
+  reparsed.should.not.containEql('<script>');
+  return alertFired(reparsed).should.eventually.be.false('alert fired after normal HTML reparse for: ' + reparsed);
+};
+
+exports.fallbackRawTextPreservesCommentSyntax = function () {
+  const document = domino.createDocument('');
+  const noscript = document.createElement('noscript');
+  const iframe = document.createElement('iframe');
+  const uppercaseNoscript = document.createElementNS('http://www.w3.org/1999/xhtml', 'NOSCRIPT');
+
+  noscript.textContent = '<!-- fallback comment -->';
+  iframe.textContent = '<!-- fallback comment -->';
+  uppercaseNoscript.textContent = '<!-- fallback comment -->';
+  document.body.appendChild(noscript);
+  document.body.appendChild(iframe);
+  document.body.appendChild(uppercaseNoscript);
+
+  document.body
+    .serialize()
+    .should.equal(
+      '<noscript><!-- fallback comment --></noscript><iframe><!-- fallback comment --></iframe><NOSCRIPT><!-- fallback comment --></NOSCRIPT>',
+    );
+};
+
+exports.fallbackRawTextPreservesCommentNodes = function () {
+  const document = domino.createDocument('');
+  const noscript = document.createElement('noscript');
+  noscript.appendChild(document.createComment('<noscript></noscript>'));
+  document.body.appendChild(noscript);
+
+  document.body
+    .serialize()
+    .should.equal('<noscript><!--<noscript></noscript>--></noscript>');
+};
+
+exports.fallbackRawTextEscapesMarkupAfterComment = function () {
+  const document = domino.createDocument('');
+  const noscript = document.createElement('noscript');
+  noscript.textContent = '<!-- fallback comment --><script>alert("comment_suffix")//</script>';
+  document.body.appendChild(noscript);
+
+  document.body
+    .serialize()
+    .should.equal(
+      '<noscript><!-- fallback comment -->&lt;script&gt;alert("comment_suffix")//&lt;/script&gt;</noscript>',
+    );
+
+  const reparsedDocument = domino.createDocument('<body>' + noscript.serialize() + '</body>');
+  reparsedDocument.getElementsByTagName('script').length.should.equal(0);
+
+  const html = reparsedDocument.serialize();
+  return alertFired(html).should.eventually.be.false('alert fired after normal HTML reparse for: ' + html);
+};
+
+exports.fallbackRawTextEscapesMarkupAfterAbruptCommentClose = async function () {
+  const cases = [
+    {
+      tagName: 'iframe',
+      payload: '<!--><script>alert("iframe_abrupt_comment")//</script>',
+      expected:
+        '<iframe><!-->&lt;script&gt;alert("iframe_abrupt_comment")//&lt;/script&gt;</iframe>',
+    },
+    {
+      tagName: 'noscript',
+      payload: '<!---><script>alert("noscript_abrupt_comment")//</script>',
+      expected:
+        '<noscript><!--->&lt;script&gt;alert("noscript_abrupt_comment")//&lt;/script&gt;</noscript>',
+    },
+    {
+      tagName: 'iframe',
+      payload: '<!--></section><script>alert("iframe_abrupt_ancestor")//</script><section>',
+      expected:
+        '<iframe><!-->&lt;/section&gt;&lt;script&gt;alert("iframe_abrupt_ancestor")//&lt;/script&gt;&lt;section&gt;</iframe>',
+    },
+    {
+      tagName: 'noscript',
+      payload: '<!---></div><script>alert("noscript_abrupt_ancestor")//</script><div>',
+      expected:
+        '<noscript><!--->&lt;/div&gt;&lt;script&gt;alert("noscript_abrupt_ancestor")//&lt;/script&gt;&lt;div&gt;</noscript>',
+    },
+  ];
+
+  for (const testCase of cases) {
+    const document = domino.createDocument('');
+    const element = document.createElement(testCase.tagName);
+    element.textContent = testCase.payload;
+    document.body.appendChild(element);
+
+    const html = document.body.serialize();
+    html.should.equal(testCase.expected);
+    html.should.not.containEql('<script>');
+
+    const reparsed = domino.createDocument('<body>' + html + '</body>').body.innerHTML;
+    reparsed.should.not.containEql('<script>');
+    const alerted = await alertFired(reparsed);
+    alerted.should.equal(false, 'alert fired after normal HTML reparse for: ' + reparsed);
+  }
+};
+
+exports.fallbackRawTextEscapesDangerousCurrentCloseInsideComment = function () {
+  const document = domino.createDocument('');
+  const noscript = document.createElement('noscript');
+  noscript.textContent = '<!--</noscript><script>alert("comment_breakout")//</script>-->';
+  document.body.appendChild(noscript);
+
+  const html = document.body.serialize();
+  html.should.equal(
+    '<noscript><!--&lt;/noscript><script>alert("comment_breakout")//</script>--></noscript>',
+  );
+
+  return alertFired(document.serialize()).should.eventually.be.false('alert fired for: ' + html);
+};
+
+exports.fallbackRawTextEscapesUppercaseCurrentCloseInsideComment = function () {
+  const document = domino.createDocument('');
+  const noscript = document.createElementNS('http://www.w3.org/1999/xhtml', 'NOSCRIPT');
+  noscript.textContent = '<!--</NOSCRIPT><script>alert("uppercase_comment_breakout")//</script>-->';
+  document.body.appendChild(noscript);
+
+  const html = document.body.serialize();
+  html.should.equal(
+    '<NOSCRIPT><!--&lt;/NOSCRIPT><script>alert("uppercase_comment_breakout")//</script>--></NOSCRIPT>',
+  );
+
+  return alertFired(document.serialize()).should.eventually.be.false('alert fired for: ' + html);
+};
+
+exports.fallbackRawTextEscapesNonAncestorClosingTag = function () {
+  const document = domino.createDocument('');
+  const main = document.createElement('main');
+  const noscript = document.createElement('noscript');
+  const iframe = document.createElement('iframe');
+  const payload = '</noscript><script>alert("noscript_iframe")//</script><noscript>';
+
+  noscript.textContent = payload;
+  iframe.textContent = payload;
+  main.appendChild(noscript);
+  main.appendChild(iframe);
+  document.body.appendChild(main);
+
+  const html = document.body.serialize();
+  html.should.not.containEql('</noscript><script>');
+  html.should.not.containEql('</script><noscript>');
+  html.should.not.containEql('<script>');
+  html.should.containEql(
+    '<iframe>&lt;/noscript&gt;&lt;script&gt;alert("noscript_iframe")//&lt;/script&gt;&lt;noscript&gt;</iframe>',
+  );
+
+  const reparsed = domino.createDocument('<body>' + iframe.serialize() + '</body>').body.innerHTML;
+  reparsed.should.not.containEql('<script>');
+  return alertFired(reparsed).should.eventually.be.false('alert fired after normal HTML reparse for: ' + reparsed);
 };
 
 exports.scriptMatchingClosingTagInRawText = function () {
@@ -362,6 +549,11 @@ exports.verifyEscapeMatchingClosingTag = function () {
       '\uD83D\uDE00</style><script>alert(1)</script>',
       'style',
       '\uD83D\uDE00&lt;/style><script>alert(1)</script>',
+    ],
+    [
+      '</NOSCRIPT><script>alert(1)</script>',
+      'NOSCRIPT',
+      '&lt;/NOSCRIPT><script>alert(1)</script>',
     ],
   ];
   for (const [rawContent, parentTag, expected] of cases) {


### PR DESCRIPTION
Escape text nodes in `iframe`, `noembed`, `noscript`, and `noframes` during HTML serialization instead of emitting attacker-controlled bytes as raw markup.

These fallback raw-content elements are inert when parsed directly by a browser, but SSR post-processing can reparse serialized HTML without preserving raw-content parser state. Escaping their text nodes prevents ancestor-closing payloads from being emitted as executable markup while preserving raw serialization for script, style, xmp, and plaintext.

More context
~https://issuetracker.google.com/u/1/issues/525899990~ ( marked as duplicated , due it was marked as a duplicate of my first report ) 


@alan-agius4 Could you please check it?

EDIT : Traceability is now available at https://issuetracker.google.com/u/1/issues/525782033