### PR TITLE
fix: escape fallback raw-content ancestor tags in comments and nested raw-text elements

### DIFF
--- a/lib/NodeUtils.js
+++ b/lib/NodeUtils.js
@@ -133,6 +133,17 @@ function attrname(a) {
   return a.name;
 }
 
+function fallbackRawContentTags(node) {
+  const tags = [];
+  while (node?.nodeType === 1 /*ELEMENT_NODE*/ && node.namespaceURI === NAMESPACE.HTML) {
+    if (hasRawContentFallback[node.tagName.toUpperCase()]) {
+      tags.push(node.localName);
+    }
+    node = node.parentNode;
+  }
+  return tags;
+}
+
 /**
  * Escapes matching closing tag in a raw text.
  *
@@ -162,12 +173,22 @@ function escapeRegExp(text) {
   return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function escapeFallbackRawText(rawText, parentTag) {
-  var result = '';
-  var index = 0;
+function escapeMatchingClosingTags(rawText, parentTag, ancestorTags) {
+  let result = escapeMatchingClosingTag(rawText, parentTag);
+  if (ancestorTags) {
+    for (const ancestorTag of ancestorTags) {
+      result = escapeMatchingClosingTag(result, ancestorTag);
+    }
+  }
+  return result;
+}
+
+function escapeFallbackRawText(rawText, parentTag, ancestorTags) {
+  let result = '';
+  let index = 0;
 
   while (index < rawText.length) {
-    var commentStart = rawText.indexOf('<!--', index);
+    const commentStart = rawText.indexOf('<!--', index);
     if (commentStart === -1) {
       result += escape(rawText.slice(index));
       break;
@@ -175,15 +196,15 @@ function escapeFallbackRawText(rawText, parentTag) {
 
     result += escape(rawText.slice(index, commentStart));
 
-    var commentEnd = findCommentEnd(rawText, commentStart + 4);
+    const commentEnd = findCommentEnd(rawText, commentStart + 4);
     if (commentEnd === -1) {
-      result += escapeMatchingClosingTag(rawText.slice(commentStart), parentTag);
+      result += escapeMatchingClosingTags(rawText.slice(commentStart), parentTag, ancestorTags);
       break;
     }
 
     // A complete HTML comment remains inert if downstream tooling reparses
     // fallback raw text as normal HTML, so preserve its comment semantics.
-    result += escapeMatchingClosingTag(rawText.slice(commentStart, commentEnd), parentTag);
+    result += escapeMatchingClosingTags(rawText.slice(commentStart, commentEnd), parentTag, ancestorTags);
     index = commentEnd;
   }
 
@@ -196,7 +217,7 @@ function findCommentEnd(rawText, index) {
   if (rawText.charAt(index) === '-' && rawText.charAt(index + 1) === '>')
     return index + 2;
 
-  var match = CLOSING_COMMENT_REGEXP.exec(rawText.slice(index));
+  const match = CLOSING_COMMENT_REGEXP.exec(rawText.slice(index));
   return match ? index + match.index + match[0].length : -1;
 }
 
@@ -249,6 +270,10 @@ function serializeOne(kid, parent) {
         var upperTag = tagname.toUpperCase();
         if (hasRawContent[upperTag] && !hasRawContentFallback[upperTag]) {
           ss = escapeMatchingClosingTag(ss, tagname);
+          const fallbackTags = fallbackRawContentTags(parent);
+          for (const fallbackTag of fallbackTags) {
+            ss = escapeMatchingClosingTag(ss, fallbackTag);
+          }
         }
         if (html && extraNewLine[tagname] && ss.charAt(0)==='\n') s += '\n';
         // Serialize children and add end tag for all others
@@ -268,13 +293,18 @@ function serializeOne(kid, parent) {
       if (hasRawContent[parenttag]) {
         // Preserve actual child element markup in fallback elements such as
         // <noscript>, but do not emit text-node payloads as raw HTML.
-        s += hasRawContentFallback[parenttag] ? escapeFallbackRawText(kid.data, parent.localName) : kid.data;
+        s += hasRawContentFallback[parenttag] ? escapeFallbackRawText(kid.data, parent.localName, fallbackRawContentTags(parent.parentNode)) : kid.data;
       } else {
         s += escape(kid.data);
       }
       break;
     case 8: //COMMENT_NODE
-      s += '<!--' + escapeClosingCommentTag(kid.data) + '-->';
+      let commentData = escapeClosingCommentTag(kid.data);
+      const fallbackTags = fallbackRawContentTags(parent);
+      for (const fallbackTag of fallbackTags) {
+        commentData = escapeMatchingClosingTag(commentData, fallbackTag);
+      }
+      s += '<!--' + commentData + '-->';
       break;
     case 7: //PROCESSING_INSTRUCTION_NODE
       const content = escapeProcessingInstructionContent(kid.data);

--- a/lib/NodeUtils.js
+++ b/lib/NodeUtils.js
@@ -136,7 +136,7 @@ function attrname(a) {
 function fallbackRawContentTags(node) {
   const tags = [];
   while (node?.nodeType === 1 /*ELEMENT_NODE*/ && node.namespaceURI === NAMESPACE.HTML) {
-    if (hasRawContentFallback[node.tagName.toUpperCase()]) {
+    if (hasRawContentFallback[node.tagName]) {
       tags.push(node.localName);
     }
     node = node.parentNode;
@@ -268,7 +268,7 @@ function serializeOne(kid, parent) {
         // If an element can have raw content, this content may
         // potentially require escaping to avoid XSS.
         var upperTag = tagname.toUpperCase();
-        if (hasRawContent[upperTag] && !hasRawContentFallback[upperTag]) {
+        if (hasRawContent[upperTag] && !hasRawContentFallback[upperTag] && ss.includes('</')) {
           ss = escapeMatchingClosingTag(ss, tagname);
           const fallbackTags = fallbackRawContentTags(parent);
           for (const fallbackTag of fallbackTags) {
@@ -300,9 +300,11 @@ function serializeOne(kid, parent) {
       break;
     case 8: //COMMENT_NODE
       let commentData = escapeClosingCommentTag(kid.data);
-      const fallbackTags = fallbackRawContentTags(parent);
-      for (const fallbackTag of fallbackTags) {
-        commentData = escapeMatchingClosingTag(commentData, fallbackTag);
+      if (commentData.includes('</')) {
+        const fallbackTags = fallbackRawContentTags(parent);
+        for (const fallbackTag of fallbackTags) {
+          commentData = escapeMatchingClosingTag(commentData, fallbackTag);
+        }
       }
       s += '<!--' + commentData + '-->';
       break;
@@ -311,20 +313,7 @@ function serializeOne(kid, parent) {
       s += '<?' + kid.target + ' ' + content + '?>';
       break;
     case 10: //DOCUMENT_TYPE_NODE
-      s += '<!DOCTYPE ' + kid.name;
-
-      if (false) {
-        // Latest HTML serialization spec omits the public/system ID
-        if (kid.publicID) {
-          s += ' PUBLIC "' + kid.publicId + '"';
-        }
-
-        if (kid.systemId) {
-          s += ' "' + kid.systemId + '"';
-        }
-      }
-
-      s += '>';
+      s += '<!DOCTYPE ' + kid.name + '>';
       break;
     default:
       utils.InvalidStateError();

--- a/test/xss.js
+++ b/test/xss.js
@@ -278,7 +278,7 @@ exports.fallbackRawTextPreservesCommentNodes = function () {
 
   document.body
     .serialize()
-    .should.equal('<noscript><!--<noscript></noscript>--></noscript>');
+    .should.equal('<noscript><!--<noscript>&lt;/noscript>--></noscript>');
 };
 
 exports.fallbackRawTextEscapesMarkupAfterComment = function () {
@@ -592,3 +592,157 @@ exports.verifyEscapeProcessingInstructionContent = function () {
     NodeUtils.ɵescapeProcessingInstructionContent(rawContent).should.equal(expected);
   }
 };
+
+exports.fallbackRawTextCommentNodeEscapesAncestorClosingTag = async function () {
+  const fallbackTags = ['noscript', 'iframe', 'noembed', 'noframes'];
+
+  for (const tag of fallbackTags) {
+    // Comment node directly inside fallback raw-content element
+    {
+      const document = domino.createDocument('');
+      const el = document.createElement(tag);
+      const comment = document.createComment(`</${tag}><img src=x onerror=alert(1)>`);
+      el.appendChild(comment);
+      document.body.appendChild(el);
+
+      const serialized = document.body.serialize();
+      serialized.should.equal(`<${tag}><!--&lt;/${tag}><img src=x onerror=alert(1)>--></${tag}>`);
+
+      const reparsed = domino.createDocument('<body>' + serialized + '</body>').body.innerHTML;
+      const alerted = await alertFired(reparsed);
+      alerted.should.equal(false, `alert fired after normal HTML reparse for comment in <${tag}>: ` + reparsed);
+    }
+
+    // Comment node inside a child element (descendant) of fallback raw-content element
+    {
+      const document = domino.createDocument('');
+      const el = document.createElement(tag);
+      const div = document.createElement('div');
+      const comment = document.createComment(`</${tag}><img src=x onerror=alert(1)>`);
+      div.appendChild(comment);
+      el.appendChild(div);
+      document.body.appendChild(el);
+
+      const serialized = document.body.serialize();
+      serialized.should.equal(`<${tag}><div><!--&lt;/${tag}><img src=x onerror=alert(1)>--></div></${tag}>`);
+
+      const reparsed = domino.createDocument('<body>' + serialized + '</body>').body.innerHTML;
+      const alerted = await alertFired(reparsed);
+      alerted.should.equal(
+        false,
+        `alert fired after normal HTML reparse for descendant comment in <${tag}>: ` + reparsed,
+      );
+    }
+
+    // Regular comments without closing tags are unchanged
+    {
+      const document = domino.createDocument('');
+      const el = document.createElement(tag);
+      const comment = document.createComment(' normal comment ');
+      el.appendChild(comment);
+      document.body.appendChild(el);
+
+      const serialized = document.body.serialize();
+      serialized.should.equal(`<${tag}><!-- normal comment --></${tag}>`);
+    }
+  }
+};
+
+exports.fallbackRawTextNestedRawTextElementsEscapeAncestorClosingTag = async function () {
+  const fallbackTags = ['noscript', 'iframe', 'noembed', 'noframes'];
+  const rawTextTags = ['xmp', 'style', 'script', 'plaintext'];
+
+  for (const fallbackTag of fallbackTags) {
+    for (const rawTextTag of rawTextTags) {
+      // Direct child non-fallback raw-text element inside fallback raw-content element
+      {
+        const document = domino.createDocument('');
+        const fallbackEl = document.createElement(fallbackTag);
+        const rawEl = document.createElement(rawTextTag);
+        rawEl.textContent = `</${fallbackTag}><img src=x onerror=alert(1)>`;
+        fallbackEl.appendChild(rawEl);
+        document.body.appendChild(fallbackEl);
+
+        const serialized = document.body.serialize();
+        serialized.should.equal(
+          `<${fallbackTag}><${rawTextTag}>&lt;/${fallbackTag}><img src=x onerror=alert(1)></${rawTextTag}></${fallbackTag}>`,
+        );
+
+        const reparsed = domino.createDocument('<body>' + serialized + '</body>').body.innerHTML;
+        const alerted = await alertFired(reparsed);
+        alerted.should.equal(
+          false,
+          `alert fired after normal HTML reparse for <${rawTextTag}> inside <${fallbackTag}>: ` + reparsed,
+        );
+      }
+
+      // Descendant non-fallback raw-text element inside a child element of fallback raw-content element
+      {
+        const document = domino.createDocument('');
+        const fallbackEl = document.createElement(fallbackTag);
+        const div = document.createElement('div');
+        const rawEl = document.createElement(rawTextTag);
+        rawEl.textContent = `</${fallbackTag}><img src=x onerror=alert(1)>`;
+        div.appendChild(rawEl);
+        fallbackEl.appendChild(div);
+        document.body.appendChild(fallbackEl);
+
+        const serialized = document.body.serialize();
+        serialized.should.equal(
+          `<${fallbackTag}><div><${rawTextTag}>&lt;/${fallbackTag}><img src=x onerror=alert(1)></${rawTextTag}></div></${fallbackTag}>`,
+        );
+
+        const reparsed = domino.createDocument('<body>' + serialized + '</body>').body.innerHTML;
+        const alerted = await alertFired(reparsed);
+        alerted.should.equal(
+          false,
+          `alert fired after normal HTML reparse for <${rawTextTag}> inside div in <${fallbackTag}>: ` + reparsed,
+        );
+      }
+    }
+  }
+};
+
+exports.fallbackRawTextTextNodeEscapesAncestorClosingTag = async function () {
+  const fallbackTags = ['noscript', 'iframe', 'noembed', 'noframes'];
+
+  for (const tag of fallbackTags) {
+    // Text node directly inside fallback raw-content element
+    {
+      const document = domino.createDocument('');
+      const el = document.createElement(tag);
+      el.textContent = `</${tag}><img src=x onerror=alert(1)>`;
+      document.body.appendChild(el);
+
+      const serialized = document.body.serialize();
+      serialized.should.equal(`<${tag}>&lt;/${tag}&gt;&lt;img src=x onerror=alert(1)&gt;</${tag}>`);
+
+      const reparsed = domino.createDocument('<body>' + serialized + '</body>').body.innerHTML;
+      reparsed.should.not.containEql('<img');
+      const alerted = await alertFired(reparsed);
+      alerted.should.equal(false, `alert fired after normal HTML reparse for text in <${tag}>: ` + reparsed);
+    }
+
+    // Text node inside a child element (descendant) of fallback raw-content element
+    {
+      const document = domino.createDocument('');
+      const el = document.createElement(tag);
+      const div = document.createElement('div');
+      div.textContent = `</${tag}><img src=x onerror=alert(1)>`;
+      el.appendChild(div);
+      document.body.appendChild(el);
+
+      const serialized = document.body.serialize();
+      serialized.should.equal(`<${tag}><div>&lt;/${tag}&gt;&lt;img src=x onerror=alert(1)&gt;</div></${tag}>`);
+
+      const reparsed = domino.createDocument('<body>' + serialized + '</body>').body.innerHTML;
+      reparsed.should.not.containEql('<img');
+      const alerted = await alertFired(reparsed);
+      alerted.should.equal(
+        false,
+        `alert fired after normal HTML reparse for descendant text in <${tag}>: ` + reparsed,
+      );
+    }
+  }
+};
+


### PR DESCRIPTION
Escape ancestor fallback raw-content element closing tags (e.g., `</noscript>`) in comment nodes, text nodes, and nested non-fallback raw-text elements (e.g., `<xmp>`, `<style>`, `<script>`, `<plaintext>`) during HTML serialization.

This prevents ancestor fallback raw-content closing tags from being emitted verbatim inside comments and nested raw-text elements, which would otherwise allow XSS breakouts after SSR de-serialization.

Closes https://github.com/angular/angular/issues/70050