### PR TITLE
fix: escape processing-instruction content under fallback raw-content elements

### DIFF
--- a/lib/NodeUtils.js
+++ b/lib/NodeUtils.js
@@ -309,7 +309,13 @@ function serializeOne(kid, parent) {
       s += '<!--' + commentData + '-->';
       break;
     case 7: //PROCESSING_INSTRUCTION_NODE
-      const content = escapeProcessingInstructionContent(kid.data);
+      let content = escapeProcessingInstructionContent(kid.data);
+      if (content.includes('</')) {
+        const fallbackTags = fallbackRawContentTags(parent);
+        for (const fallbackTag of fallbackTags) {
+          content = escapeMatchingClosingTag(content, fallbackTag);
+        }
+      }
       s += '<?' + kid.target + ' ' + content + '?>';
       break;
     case 10: //DOCUMENT_TYPE_NODE

--- a/test/domino.js
+++ b/test/domino.js
@@ -1556,3 +1556,45 @@ exports.worksWithBase64DataImages = function () {
       'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII);"></div>'
   );
 };
+
+exports.processingInstructionClosingTagEscapedInNoscript = function () {
+  // A processing-instruction payload that begins with a fallback raw-content
+  // closing tag (e.g. `</noscript `) must have that prefix escaped during
+  // serialization. Otherwise the serialized output closes the <noscript>
+  // element early in the receiving browser (RAWTEXT) and the sibling
+  // <img onerror> is re-parsed as live HTML.
+  // Regression for angular/angular#70146: the fc7e40a (#70050) and e0779df
+  // (#70055) fixes escaped element/text/comment branches of serializeOne()
+  // but the PROCESSING_INSTRUCTION_NODE branch (case 7) never called
+  // fallbackRawContentTags(), and escapeProcessingInstructionContent()
+  // only escapes `>` (leaving `<` alone).
+  const document = domino.createDocument('<html><body></body></html>');
+  const noscript = document.createElement('noscript');
+  noscript.appendChild(document.createProcessingInstruction('x', '</noscript '));
+  const img = document.createElement('img');
+  img.setAttribute('src', 'x');
+  img.setAttribute('onerror', 'alert(1)');
+  noscript.appendChild(img);
+  document.body.appendChild(noscript);
+
+  const html = document.body.serialize();
+  html.should.equal(
+    '<noscript><?x &lt;/noscript ?><img src="x" onerror="alert(1)"></noscript>'
+  );
+  // The PI payload must not leak an unescaped closing-tag prefix.
+  html.should.not.containEql('<?x </noscript');
+};
+
+exports.processingInstructionClosingTagEscapedForAllFallbackElements = function () {
+  const document = domino.createDocument('');
+  for (const tagName of ['noscript', 'iframe', 'noembed', 'noframes']) {
+    const fallback = document.createElement(tagName);
+    fallback.appendChild(document.createProcessingInstruction('x', '</' + tagName + '/'));
+    document.body.appendChild(fallback);
+
+    const html = document.body.serialize();
+    html.should.containEql('<?x &lt;/' + tagName + '/?>');
+    html.should.not.containEql('<?x </' + tagName);
+    document.body.removeChild(fallback);
+  }
+};


### PR DESCRIPTION
Fixes angular/angular#70146

## What

This is the remaining piece of the #70050 / #70055 fallback raw-content escaping work. Those fixes (`fc7e40a`, `e0779df`) added closing-tag escaping to the element, text and comment branches of `serializeOne()`, but the PROCESSING_INSTRUCTION_NODE branch (case 7) was never covered.

`escapeProcessingInstructionContent()` escapes only `>` and deliberately leaves `<` alone. Under a fallback raw-content ancestor (`noscript`, `iframe`, `noembed`, `noframes`) the browser tokenizer looks only for `</tag`; a processing-instruction payload such as `</noscript ` passes `createProcessingInstruction()` validation (only `?>` is rejected in `lib/Document.js`) and is emitted unescaped. The fallback element then closes early in the browser and sibling markup (e.g. `<img src=x onerror=alert(1)>`) is re-parsed as live HTML.

## Fix

Mirror the comment branch (`case 8`): after `escapeProcessingInstructionContent()`, when the content contains `</`, escape the matching closing tag for every fallback raw-content ancestor returned by `fallbackRawContentTags(parent)`.

```js
case 7: //PROCESSING_INSTRUCTION_NODE
  let content = escapeProcessingInstructionContent(kid.data);
  if (content.includes('</')) {
    const fallbackTags = fallbackRawContentTags(parent);
    for (const fallbackTag of fallbackTags) {
      content = escapeMatchingClosingTag(content, fallbackTag);
    }
  }
  s += '<?' + kid.target + ' ' + content + '?>';
  break;
```

For the issue's payload the output becomes `<?x &lt;/noscript ?>` instead of `<?x </noscript ?>`. The 11 breaking shapes described in the issue are covered, and the control shapes from #70050 / #70055 are unchanged.

## Verification

Added regression tests in `test/domino.js`. They are deliberately kept free of the puppeteer/browser dependency that `test/xss.js` uses (the `before` hook there launches a browser), so the serializer behavior is exercised directly and deterministically:

- `processingInstructionClosingTagEscapedInNoscript` reproduces the exact issue shape (`<noscript><?x </noscript ?><img src="x" onerror="alert(1)">`), asserting the escaped serialized output and that the PI payload leaks no unescaped `<?x </noscript`.
- `processingInstructionClosingTagEscapedForAllFallbackElements` covers all four fallback elements (`noscript`, `iframe`, `noembed`, `noframes`) with a `</tag/` payload.

Verified with `pnpm exec mocha test/domino.js -g processingInstruction`: the tests fail on `main` (the `</noscript ` prefix is emitted unescaped) and pass with the fix.

## Notes

The issue is tracked in angular/angular; the fix itself lives in the vendored `domino` serializer, so this PR targets angular/domino (this is where the #70050 / #70055 fixes also landed). A follow-up dependency bump in angular/angular will be needed to pick this up once released.