### PR TITLE
fix: escape fallback raw-content ancestor tags in processing instructions

### DIFF
--- a/lib/NodeUtils.js
+++ b/lib/NodeUtils.js
@@ -309,7 +309,13 @@ function serializeOne(kid, parent) {
       s += '<!--' + commentData + '-->';
       break;
     case 7: //PROCESSING_INSTRUCTION_NODE
-      const content = escapeProcessingInstructionContent(kid.data);
+      let content = escapeProcessingInstructionContent(kid.data);
+      if (content.includes('</')) {
+        const fallbackTags = fallbackRawContentTags(parent);
+        for (const fallbackTag of fallbackTags) {
+          content = escapeMatchingClosingTag(content, fallbackTag);
+        }
+      }
       s += '<?' + kid.target + ' ' + content + '?>';
       break;
     case 10: //DOCUMENT_TYPE_NODE

--- a/test/xss.js
+++ b/test/xss.js
@@ -509,6 +509,27 @@ exports.badProcessingInstruction = function () {
   return alertFired(html).should.eventually.be.false('alert fired for: ' + html);
 };
 
+exports.noscriptProcessingInstructionAncestorClosingTagEscaped = function () {
+  const document = domino.createDocument('');
+  const noscript = document.createElement('noscript');
+  const pi = document.createProcessingInstruction('x', '</noscript ');
+  noscript.appendChild(pi);
+  const img = document.createElement('img');
+  img.setAttribute('src', 'x');
+  img.setAttribute('onerror', 'alert(1)');
+  noscript.appendChild(img);
+  document.body.appendChild(noscript);
+
+  document.body
+    .serialize()
+    .should.equal(
+      '<noscript><?x &lt;/noscript ?><img src="x" onerror="alert(1)"></noscript>',
+    );
+
+  const html = document.serialize();
+  return alertFired(html).should.eventually.be.false('alert fired for: ' + html);
+};
+
 exports.verifyEscapeMatchingClosingTag = function () {
   const cases = [
     ['', 'style', ''], // no artifacts while processing an empty string


### PR DESCRIPTION
## Summary

Fixes the remaining part of the regression reported in angular/angular#70050 / #70055, tracked as angular/angular#70146.

`serializeOne()`'s `PROCESSING_INSTRUCTION_NODE` branch (case 7) never called `fallbackRawContentTags()`/`escapeMatchingClosingTag()`, unlike the `COMMENT_NODE` branch (case 8) fixed in fc7e40a. `escapeProcessingInstructionContent()` only escapes `>`, so a literal `</noscript` (or `</iframe`, `</noembed`, `</noframes`) sequence in PI data passes through untouched and reaches the browser's RAWTEXT tokenizer unescaped, closing the fallback element early and exposing following sibling markup (e.g. an `<img onerror>`) as live DOM.

This mirrors the fix already applied to the comment-node branch, escaping the ancestor's closing tag inside PI content the same way.

## Test plan

- [x] Added `noscriptProcessingInstructionAncestorClosingTagEscaped` to `test/xss.js`, verifying both the exact escaped serialization and that no alert fires when the resulting HTML is loaded in a real browser (puppeteer).
- [x] Confirmed the new test fails without the fix and passes with it.
- [x] `npx mocha test/domino.js test/parsing.js test/readonly.js test/xss.js` — all passing (excluding one pre-existing, unrelated timeout in `fallbackRawTextNestedRawTextElementsEscapeAncestorClosingTag` that reproduces identically without this change).