### PR TITLE
fix: escape fallback raw-content ancestor tags in templates and processing instructions

### DIFF
--- a/lib/NodeUtils.js
+++ b/lib/NodeUtils.js
@@ -135,11 +135,17 @@ function attrname(a) {
 
 function fallbackRawContentTags(node) {
   const tags = [];
-  while (node?.nodeType === 1 /*ELEMENT_NODE*/) {
-    if (node.namespaceURI === NAMESPACE.HTML && hasRawContentFallback[node.tagName]) {
-      tags.push(node.localName);
+  while (node) {
+    if (node.nodeType === 1 /*ELEMENT_NODE*/) {
+      if (node.namespaceURI === NAMESPACE.HTML && hasRawContentFallback[node.tagName]) {
+        tags.push(node.localName);
+      }
+      node = node.parentNode;
+    } else if (node.nodeType === 11 /*DOCUMENT_FRAGMENT_NODE*/ && node._host) {
+      node = node._host;
+    } else {
+      node = node.parentNode;
     }
-    node = node.parentNode;
   }
   return tags;
 }
@@ -309,7 +315,13 @@ function serializeOne(kid, parent) {
       s += '<!--' + commentData + '-->';
       break;
     case 7: //PROCESSING_INSTRUCTION_NODE
-      const content = escapeProcessingInstructionContent(kid.data);
+      let content = escapeProcessingInstructionContent(kid.data);
+      if (content.includes('</')) {
+        const fallbackTags = fallbackRawContentTags(parent);
+        for (const fallbackTag of fallbackTags) {
+          content = escapeMatchingClosingTag(content, fallbackTag);
+        }
+      }
       s += '<?' + kid.target + ' ' + content + '?>';
       break;
     case 10: //DOCUMENT_TYPE_NODE

--- a/lib/htmlelts.js
+++ b/lib/htmlelts.js
@@ -1141,10 +1141,21 @@ define({
   ctor: function HTMLTemplateElement(doc, localName, prefix) {
     HTMLElement.call(this, doc, localName, prefix);
     this._contentFragment = doc._templateDoc.createDocumentFragment();
+    this._contentFragment._host = this;
   },
   props: {
     content: { get: function() { return this._contentFragment; } },
-    serialize: { value: function() { return this.content.serialize(); } }
+    serialize: { value: function() { return this.content.serialize(); } },
+    cloneNode: {
+      value: function(deep) {
+        var clone = HTMLElement.prototype.cloneNode.call(this, deep);
+        if (deep) {
+          clone._contentFragment = this._contentFragment.cloneNode(true);
+          clone._contentFragment._host = clone;
+        }
+        return clone;
+      }
+    }
   }
 });
 

--- a/test/domino.js
+++ b/test/domino.js
@@ -1556,3 +1556,72 @@ exports.worksWithBase64DataImages = function () {
       'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII);"></div>'
   );
 };
+
+exports.processingInstructionClosingTagEscapedInNoscript = function () {
+  const document = domino.createDocument('<html><body></body></html>');
+  const noscript = document.createElement('noscript');
+  noscript.appendChild(document.createProcessingInstruction('x', '</noscript '));
+  const img = document.createElement('img');
+  img.setAttribute('src', 'x');
+  img.setAttribute('onerror', 'alert(1)');
+  noscript.appendChild(img);
+  document.body.appendChild(noscript);
+
+  const html = document.body.serialize();
+  html.should.equal(
+    '<noscript><?x &lt;/noscript ?><img src="x" onerror="alert(1)"></noscript>'
+  );
+  html.should.not.containEql('<?x </noscript');
+};
+
+exports.processingInstructionClosingTagEscapedForAllFallbackElements = function () {
+  const document = domino.createDocument('');
+  for (const tagName of ['noscript', 'iframe', 'noembed', 'noframes']) {
+    const fallback = document.createElement(tagName);
+    fallback.appendChild(document.createProcessingInstruction('x', '</' + tagName + '/'));
+    document.body.appendChild(fallback);
+
+    const html = document.body.serialize();
+    html.should.containEql('<?x &lt;/' + tagName + '/?>');
+    html.should.not.containEql('<?x </' + tagName);
+    document.body.removeChild(fallback);
+  }
+};
+
+exports.templateContentInFallbackElementsEscaped = function () {
+  const document = domino.createDocument('');
+  for (const tagName of ['noscript', 'iframe', 'noembed', 'noframes']) {
+    const fallback = document.createElement(tagName);
+    const template = document.createElement('template');
+    const xmp = document.createElement('xmp');
+    xmp.textContent = '</' + tagName + '><img src=x onerror=alert(1)>';
+    template.content.appendChild(xmp);
+    fallback.appendChild(template);
+    document.body.appendChild(fallback);
+
+    const html = document.body.serialize();
+    html.should.equal(
+      '<' + tagName + '><template><xmp>&lt;/' + tagName + '><img src=x onerror=alert(1)></xmp></template></' + tagName + '>'
+    );
+    document.body.removeChild(fallback);
+  }
+};
+
+exports.clonedTemplateContentMaintainsHostReference = function () {
+  const document = domino.createDocument('');
+  const fallback = document.createElement('noscript');
+  const template = document.createElement('template');
+  const xmp = document.createElement('xmp');
+  xmp.textContent = '</noscript><img src=x onerror=alert(1)>';
+  template.content.appendChild(xmp);
+
+  const clonedTemplate = template.cloneNode(true);
+  fallback.appendChild(clonedTemplate);
+  document.body.appendChild(fallback);
+
+  const html = document.body.serialize();
+  html.should.equal(
+    '<noscript><template><xmp>&lt;/noscript><img src=x onerror=alert(1)></xmp></template></noscript>'
+  );
+};
+

--- a/test/xss.js
+++ b/test/xss.js
@@ -869,3 +869,121 @@ exports.fallbackRawTextForeignContentEscapesAncestorClosingTag = async function 
     }
   }
 };
+
+exports.fallbackRawTextTemplateContentEscapesAncestorClosingTag = async function () {
+  const fallbackTags = ['noscript', 'iframe', 'noembed', 'noframes'];
+
+  for (const tag of fallbackTags) {
+    // noscript/iframe/noembed/noframes > template > xmp
+    {
+      const document = domino.createDocument('');
+      const fallbackEl = document.createElement(tag);
+      const template = document.createElement('template');
+      const xmp = document.createElement('xmp');
+      xmp.textContent = `</${tag}><img src=x onerror=alert(1)>`;
+      template.content.appendChild(xmp);
+      fallbackEl.appendChild(template);
+      document.body.appendChild(fallbackEl);
+
+      const serialized = document.body.serialize();
+      serialized.should.equal(
+        `<${tag}><template><xmp>&lt;/${tag}><img src=x onerror=alert(1)></xmp></template></${tag}>`,
+      );
+
+      const reparsedDoc = domino.createDocument('<body>' + serialized + '</body>');
+      reparsedDoc.getElementsByTagName('img').length.should.equal(0);
+
+      const reparsed = reparsedDoc.body.innerHTML;
+      reparsed.should.not.containEql(`</${tag}><img`);
+      const alerted = await alertFired(reparsed);
+      alerted.should.equal(
+        false,
+        `alert fired after normal HTML reparse for template xmp in <${tag}>: ` + reparsed,
+      );
+    }
+
+    // noscript/iframe/noembed/noframes > template > #comment
+    {
+      const document = domino.createDocument('');
+      const fallbackEl = document.createElement(tag);
+      const template = document.createElement('template');
+      const comment = document.createComment(`</${tag}><img src=x onerror=alert(1)>`);
+      template.content.appendChild(comment);
+      fallbackEl.appendChild(template);
+      document.body.appendChild(fallbackEl);
+
+      const serialized = document.body.serialize();
+      serialized.should.equal(
+        `<${tag}><template><!--&lt;/${tag}><img src=x onerror=alert(1)>--></template></${tag}>`,
+      );
+
+      const reparsedDoc = domino.createDocument('<body>' + serialized + '</body>');
+      reparsedDoc.getElementsByTagName('img').length.should.equal(0);
+
+      const reparsed = reparsedDoc.body.innerHTML;
+      reparsed.should.not.containEql(`</${tag}><img`);
+      const alerted = await alertFired(reparsed);
+      alerted.should.equal(
+        false,
+        `alert fired after normal HTML reparse for template comment in <${tag}>: ` + reparsed,
+      );
+    }
+  }
+};
+
+exports.fallbackRawTextProcessingInstructionEscapesAncestorClosingTag = async function () {
+  const fallbackTags = ['noscript', 'iframe', 'noembed', 'noframes'];
+
+  for (const tag of fallbackTags) {
+    // noscript/iframe/noembed/noframes > ProcessingInstruction
+    {
+      const document = domino.createDocument('');
+      const fallbackEl = document.createElement(tag);
+      fallbackEl.appendChild(document.createProcessingInstruction('x', `</${tag}><img src=x onerror=alert(1)>`));
+      document.body.appendChild(fallbackEl);
+
+      const serialized = document.body.serialize();
+      serialized.should.equal(
+        `<${tag}><?x &lt;/${tag}&gt;<img src=x onerror=alert(1)&gt;?></${tag}>`,
+      );
+
+      const reparsedDoc = domino.createDocument('<body>' + serialized + '</body>');
+      reparsedDoc.getElementsByTagName('img').length.should.equal(0);
+
+      const reparsed = reparsedDoc.body.innerHTML;
+      reparsed.should.not.containEql(`</${tag}><img`);
+      const alerted = await alertFired(reparsed);
+      alerted.should.equal(
+        false,
+        `alert fired after normal HTML reparse for PI in <${tag}>: ` + reparsed,
+      );
+    }
+
+    // noscript/iframe/noembed/noframes > template > ProcessingInstruction
+    {
+      const document = domino.createDocument('');
+      const fallbackEl = document.createElement(tag);
+      const template = document.createElement('template');
+      template.content.appendChild(document.createProcessingInstruction('x', `</${tag}><img src=x onerror=alert(1)>`));
+      fallbackEl.appendChild(template);
+      document.body.appendChild(fallbackEl);
+
+      const serialized = document.body.serialize();
+      serialized.should.equal(
+        `<${tag}><template><?x &lt;/${tag}&gt;<img src=x onerror=alert(1)&gt;?></template></${tag}>`,
+      );
+
+      const reparsedDoc = domino.createDocument('<body>' + serialized + '</body>');
+      reparsedDoc.getElementsByTagName('img').length.should.equal(0);
+
+      const reparsed = reparsedDoc.body.innerHTML;
+      reparsed.should.not.containEql(`</${tag}><img`);
+      const alerted = await alertFired(reparsed);
+      alerted.should.equal(
+        false,
+        `alert fired after normal HTML reparse for template PI in <${tag}>: ` + reparsed,
+      );
+    }
+  }
+};
+


### PR DESCRIPTION
Escape ancestor fallback raw-content element closing tags (e.g., `</noscript>`) when serializing `ProcessingInstruction` nodes and when traversing `DocumentFragment` boundaries in `<template>` element content.



1. **`<template>` DocumentFragment Boundary (GHSA-v3p8-whq6-r5jg)**:
   - A `<template>` element stores its children in a separate `DocumentFragment` (`template.content`, `nodeType === 11`). Because `fallbackRawContentTags(node)` previously only traversed `nodeType === 1` elements, ancestor walks terminated at the fragment boundary without discovering enclosing fallback raw-content ancestors (such as `<noscript>` or `<iframe>`).
   - We attach a `_host` reference from the `<template>` element's `_contentFragment` back to the host `<template>` element (and preserve this across deep cloning via `cloneNode`).
   - `fallbackRawContentTags(node)` is updated to traverse from a `DocumentFragment` node to its `_host`, enabling discovery of fallback raw-content ancestors across template boundaries.

2. **`ProcessingInstruction` Nodes (angular/angular#70146)**:
   - `serializeOne()` (`case 7: //PROCESSING_INSTRUCTION_NODE`) previously only escaped `>` via `escapeProcessingInstructionContent()`, without checking for matching fallback raw-content closing tags.
   - We mirror the comment node (`case 8`) logic: when PI data contains `</`, we check `fallbackRawContentTags(parent)` and escape matching closing tags (e.g., `</noscript` -> `&lt;/noscript`).


Fixes https://github.com/angular/angular/issues/70146