### PR TITLE
fix: escape ancestor closing tags inside escapable raw text elements (<textarea>, <title>)

### DIFF
--- a/lib/NodeUtils.js
+++ b/lib/NodeUtils.js
@@ -43,6 +43,18 @@ var hasRawContentFallback = {
   NOFRAMES: true
 };
 
+// HTML's *escapable raw text* elements (a.k.a. RCDATA). Unlike the raw-text
+// elements above, their text content IS escaped for character references --
+// but the element is still terminated only by its own closing tag. So any
+// payload that we emit verbatim underneath one of them (comment data,
+// processing-instruction data, or the serialization of a nested raw-content
+// element) must have that closing tag escaped, or it breaks the element open.
+// https://html.spec.whatwg.org/multipage/syntax.html#escapable-raw-text-elements
+var hasEscapableRawContent = {
+  TEXTAREA: true,
+  TITLE: true
+};
+
 var emptyElements = {
   area: true,
   base: true,
@@ -137,7 +149,9 @@ function fallbackRawContentTags(node) {
   const tags = [];
   while (node) {
     if (node.nodeType === 1 /*ELEMENT_NODE*/) {
-      if (node.namespaceURI === NAMESPACE.HTML && hasRawContentFallback[node.tagName]) {
+      if (node.namespaceURI === NAMESPACE.HTML &&
+          (hasRawContentFallback[node.tagName] ||
+           hasEscapableRawContent[node.tagName])) {
         tags.push(node.localName);
       }
       node = node.parentNode;

--- a/test/xss.js
+++ b/test/xss.js
@@ -1077,3 +1077,89 @@ exports.fallbackRawTextCommentNodeEscapesAbruptClosingComment = async function (
     );
   }
 };
+
+// HTML's *escapable raw text* elements (RCDATA): <textarea> and <title>. Their
+// text content is escaped for character references, but the element is still
+// terminated only by its own closing tag -- so anything we emit verbatim
+// underneath one of them must have that closing tag escaped, exactly as for the
+// fallback raw-content elements above.
+exports.escapableRawTextCommentNodeEscapesAncestorClosingTag = async function () {
+  const escapableTags = ['textarea', 'title'];
+
+  for (const tag of escapableTags) {
+    // Comment node directly inside escapable raw-text element
+    {
+      const document = domino.createDocument('');
+      const el = document.createElement(tag);
+      const comment = document.createComment(`</${tag}><img src=x onerror=alert(1)>`);
+      el.appendChild(comment);
+      document.body.appendChild(el);
+
+      const serialized = document.body.serialize();
+      serialized.should.equal(`<${tag}><!--&lt;/${tag}><img src=x onerror=alert(1)>--></${tag}>`);
+
+      const reparsed = domino.createDocument('<body>' + serialized + '</body>').body.innerHTML;
+      const alerted = await alertFired(reparsed);
+      alerted.should.equal(false, `alert fired after normal HTML reparse for comment in <${tag}>: ` + reparsed);
+    }
+
+    // Comment node inside a child element (descendant) of escapable raw-text element
+    {
+      const document = domino.createDocument('');
+      const el = document.createElement(tag);
+      const div = document.createElement('div');
+      const comment = document.createComment(`</${tag}><img src=x onerror=alert(1)>`);
+      div.appendChild(comment);
+      el.appendChild(div);
+      document.body.appendChild(el);
+
+      const serialized = document.body.serialize();
+      serialized.should.equal(
+        `<${tag}><div><!--&lt;/${tag}><img src=x onerror=alert(1)>--></div></${tag}>`);
+
+      const reparsed = domino.createDocument('<body>' + serialized + '</body>').body.innerHTML;
+      const alerted = await alertFired(reparsed);
+      alerted.should.equal(false, `alert fired after normal HTML reparse for descendant comment in <${tag}>: ` + reparsed);
+    }
+  }
+};
+
+exports.escapableRawTextProcessingInstructionEscapesAncestorClosingTag = async function () {
+  const escapableTags = ['textarea', 'title'];
+
+  for (const tag of escapableTags) {
+    const document = domino.createDocument('');
+    const el = document.createElement(tag);
+    const pi = document.createProcessingInstruction('x', `</${tag}><img src=x onerror=alert(1)>`);
+    el.appendChild(pi);
+    document.body.appendChild(el);
+
+    const serialized = document.body.serialize();
+    serialized.should.containEql(`&lt;/${tag}`);
+    serialized.should.not.containEql(`</${tag}><img`);
+
+    const reparsed = domino.createDocument('<body>' + serialized + '</body>').body.innerHTML;
+    const alerted = await alertFired(reparsed);
+    alerted.should.equal(false, `alert fired after normal HTML reparse for PI in <${tag}>: ` + reparsed);
+  }
+};
+
+exports.escapableRawTextNestedRawTextElementsEscapeAncestorClosingTag = async function () {
+  const escapableTags = ['textarea', 'title'];
+
+  for (const tag of escapableTags) {
+    const document = domino.createDocument('');
+    const el = document.createElement(tag);
+    const style = document.createElement('style');
+    style.appendChild(document.createTextNode(`</${tag}><img src=x onerror=alert(1)>`));
+    el.appendChild(style);
+    document.body.appendChild(el);
+
+    const serialized = document.body.serialize();
+    serialized.should.not.containEql(`</${tag}><img`);
+
+    const reparsed = domino.createDocument('<body>' + serialized + '</body>').body.innerHTML;
+    const alerted = await alertFired(reparsed);
+    alerted.should.equal(false, `alert fired after normal HTML reparse for nested <style> in <${tag}>: ` + reparsed);
+  }
+};


### PR DESCRIPTION
The August hardening of `fallbackRawContentTags()` covers the HTML **raw text** elements
(`<iframe>`, `<noembed>`, `<noscript>`, `<noframes>`), but not the **escapable raw text** elements —
`<textarea>` and `<title>`.

Those two are terminated the same way: only by their own closing tag. So anything the serializer
emits verbatim underneath one of them — comment data, processing-instruction data, or the
serialization of a nested raw-text element — can close the element early and turn the remainder of
the payload into live markup.

At `7df6545`, eight variants of this produce an executing `<img onerror>` after a normal HTML
reparse:

| payload | host | before |
|---|---|---|
| comment | `<textarea>` | `<textarea><!--</textarea><img src=x onerror=alert(1)>--></textarea>` |
| comment | `<title>` | `<title><!--</title><img src=x onerror=alert(1)>--></title>` |
| nested `<style>` / `<script>` / `<xmp>` | `<textarea>` | `<textarea><style></textarea><img src=x onerror=alert(1)></style></textarea>` |
| nested `<style>` / `<script>` / `<xmp>` | `<title>` | `<title><style></title><img src=x onerror=alert(1)></style></title>` |

Processing instructions happen to survive today, because `escapeProcessingInstructionContent()`
rewrites the `>` and `</textarea&` is not a valid end tag — but that is incidental rather than
intended, so the tests below cover it as well.

## The change

`fallbackRawContentTags()` already collects the ancestor tags whose closing sequence must be escaped
out of nested verbatim data; it just never sees `<textarea>` or `<title>`, because they are not in
`hasRawContentFallback`.

They do not belong in that object either — its own comment says the text in those elements "is inert
for browser parsing", which is exactly what is *not* true of RCDATA: `<textarea>` and `<title>` text
**is** escaped for character references. Overloading the set would make the two families
indistinguishable for any future change that reads it for its documented meaning.

So this adds a separate `hasEscapableRawContent` set, named after the spec
([escapable raw text elements](https://html.spec.whatwg.org/multipage/syntax.html#escapable-raw-text-elements)),
and has the ancestor walk consult both:

```js
var hasEscapableRawContent = {
  TEXTAREA: true,
  TITLE: true
};
```

```diff
-      if (node.namespaceURI === NAMESPACE.HTML && hasRawContentFallback[node.tagName]) {
+      if (node.namespaceURI === NAMESPACE.HTML &&
+          (hasRawContentFallback[node.tagName] ||
+           hasEscapableRawContent[node.tagName])) {
         tags.push(node.localName);
       }
```

That is the whole behavioural change. `hasEscapableRawContent` is deliberately *not* consulted by
the text-node path at `NodeUtils.js:322-328` or the element path at `:300`: both are gated on
`hasRawContent`, and `<textarea>`/`<title>` text must keep going through `escape()` as it does today.

## Tests

Three new cases in `test/xss.js`, following the existing `fallbackRawText*` structure and using the
same puppeteer `alertFired()` oracle:

- `escapableRawTextCommentNodeEscapesAncestorClosingTag` — comment as a direct child and as a
  descendant, for both tags
- `escapableRawTextProcessingInstructionEscapesAncestorClosingTag`
- `escapableRawTextNestedRawTextElementsEscapeAncestorClosingTag`

```
$ npx mocha test/xss.js test/domino.js test/parsing.js test/readonly.js
  1686 passing        # 1683 before, +3 new
```

Each new test fails on the unpatched tree, e.g.:

```
AssertionError: expected '<textarea><!--</textarea><img src=x onerror=alert(1)>--></textarea>'
              to be '<textarea><!--&lt;/textarea><img src=x onerror=alert(1)>--></textarea>'
```

## Provenance

Reported to the Google VRP first (issue 555531833). It was closed on 2026-09-04 as not meeting their
internal escalation threshold, with *"Please feel free to publicly disclose this issue on GitHub as a
public issue."* — hence this PR.

The same serializer obligation has been accepted twice before, in GHSA-j3r3-mxqp-r2p4 (PI data not
escaping an enclosing text-only element's closing tag) and GHSA-v3p8-whq6-r5jg (ancestor walk
terminating early at a `DocumentFragment` boundary). Both corrected *how* the walk traverses; this
corrects *what it recognises*.

`angular/angular` pins this repo at `7df65450b833…` in `package.json`, so the path reaches Angular
SSR output via `platform-server`.
