### PR TITLE
fix: align fallback checks with serialized tag names

### DIFF
--- a/lib/NodeUtils.js
+++ b/lib/NodeUtils.js
@@ -145,14 +145,22 @@ function attrname(a) {
   return a.name;
 }
 
+function serializedTagName(node) {
+  var ns = node.namespaceURI;
+  return (ns === NAMESPACE.HTML || ns === NAMESPACE.SVG || ns === NAMESPACE.MATHML)
+    ? node.localName
+    : node.tagName;
+}
+
 function fallbackRawContentTags(node) {
   const tags = [];
   while (node) {
     if (node.nodeType === 1 /*ELEMENT_NODE*/) {
-      if (node.namespaceURI === NAMESPACE.HTML &&
-          (hasRawContentFallback[node.tagName] ||
-           hasEscapableRawContent[node.tagName])) {
-        tags.push(node.localName);
+      const tagname = serializedTagName(node);
+      if (tagname &&
+          (hasRawContentFallback[tagname.toUpperCase()] ||
+           hasEscapableRawContent[tagname.toUpperCase()])) {
+        tags.push(tagname);
       }
       node = node.parentNode;
     } else if (node.nodeType === 11 /*DOCUMENT_FRAGMENT_NODE*/ && node._host) {
@@ -295,7 +303,7 @@ function serializeOne(kid, parent) {
     case 1: //ELEMENT_NODE
       var ns = kid.namespaceURI;
       var html = ns === NAMESPACE.HTML;
-      var tagname = (html || ns === NAMESPACE.SVG || ns === NAMESPACE.MATHML) ? kid.localName : kid.tagName;
+      var tagname = serializedTagName(kid);
 
       s += '<' + tagname;
 

--- a/test/xss.js
+++ b/test/xss.js
@@ -1001,6 +1001,70 @@ exports.fallbackRawTextProcessingInstructionEscapesAncestorClosingTag = async fu
   }
 };
 
+exports.fallbackRawTextProcessingInstructionUsesSerializedAncestorName = async function () {
+  const cases = [
+    {
+      label: 'SVG noembed',
+      namespace: 'http://www.w3.org/2000/svg',
+      qualifiedName: 'noembed',
+      serializedName: 'noembed',
+    },
+    {
+      label: 'MathML noembed',
+      namespace: 'http://www.w3.org/1998/Math/MathML',
+      qualifiedName: 'noembed',
+      serializedName: 'noembed',
+    },
+    {
+      label: 'SVG iframe',
+      namespace: 'http://www.w3.org/2000/svg',
+      qualifiedName: 'iframe',
+      serializedName: 'iframe',
+    },
+    {
+      label: 'qualified HTML iframe',
+      namespace: 'http://www.w3.org/1999/xhtml',
+      qualifiedName: 'x:iframe',
+      serializedName: 'iframe',
+    },
+  ];
+
+  for (const testCase of cases) {
+    const document = domino.createDocument('');
+    const fallbackEl = document.createElementNS(
+      testCase.namespace,
+      testCase.qualifiedName,
+    );
+
+    fallbackEl.appendChild(
+      document.createProcessingInstruction(
+        'x',
+        `</${testCase.serializedName} `,
+      ),
+    );
+
+    const img = document.createElement('img');
+    img.setAttribute('src', 'x');
+    img.setAttribute('onerror', 'alert(1)');
+    fallbackEl.appendChild(img);
+
+    document.body.appendChild(fallbackEl);
+
+    const serialized = document.body.serialize();
+
+    serialized.should.containEql(
+      `<?x &lt;/${testCase.serializedName} ?>`,
+      `${testCase.label}: matching fallback closing tag was not escaped: ${serialized}`,
+    );
+
+    const alerted = await alertFired(serialized);
+    alerted.should.equal(
+      false,
+      `alert fired for PI under ${testCase.label}: ${serialized}`,
+    );
+  }
+};
+
 exports.commentNodeEscapesAbruptClosingComment = async function () {
   // A comment content that starts with `>` or `->` is closed by the parser
   // right away (the "abrupt-closing-of-empty-comment" parse error), so the rest


### PR DESCRIPTION
## PR Checklist

* [x] The commit message follows the project commit message guidelines
* [x] Tests for the changes have been added
* [x] The full repository test suite passes

## PR Type

* [x] Bugfix
* [x] Security hardening
* [ ] Feature
* [ ] Code style update
* [x] Refactoring
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Other

## What is the current behavior?

Domino uses different element identities when determining whether an ancestor is a fallback raw-content element and when serializing that same element.

`fallbackRawContentTags()` currently only recognizes fallback ancestors in the HTML namespace:

```js id="tln76d"
if (
  node.namespaceURI === NAMESPACE.HTML &&
  hasRawContentFallback[node.tagName]
) {
  tags.push(node.localName);
}
```

However, `serializeOne()` serializes HTML, SVG, and MathML elements using `localName`:

```js id="8zfqsn"
var tagname =
  (html || ns === NAMESPACE.SVG || ns === NAMESPACE.MATHML)
    ? kid.localName
    : kid.tagName;
```

This means an element can be omitted from the fallback raw-content ancestor check while still being emitted with a fallback raw-content tag name such as `noembed` or `iframe`.

For example:

```js id="k49a16"
const fallback = document.createElementNS(
  'http://www.w3.org/2000/svg',
  'noembed',
);
```

is serialized as:

```html id="ctbho6"
<noembed>
```

but was not previously recognized as a `noembed` ancestor by `fallbackRawContentTags()`.

This affects the existing `ProcessingInstruction` closing-tag protection.

Given:

```js id="f8uxu8"
const pi = document.createProcessingInstruction(
  'x',
  '</noembed ',
);
```

followed by a sibling:

```js id="o9k7wc"
const img = document.createElement('img');
img.setAttribute('src', 'x');
img.setAttribute('onerror', 'alert(1)');
```

the unpatched serializer can produce:

```html id="qodl7m"
<noembed><?x </noembed ?><img src="x" onerror="alert(1)"></noembed>
```

When the serialized SSR output is parsed as HTML, the matching `</noembed ` sequence terminates the fallback raw-content context and the following sibling is parsed as active HTML.

## What is the new behavior?

Element-name selection is centralized in a shared helper:

```js id="w3z2rc"
function serializedTagName(node) {
  var ns = node.namespaceURI;
  return (
    ns === NAMESPACE.HTML ||
    ns === NAMESPACE.SVG ||
    ns === NAMESPACE.MATHML
  )
    ? node.localName
    : node.tagName;
}
```

`serializeOne()` uses the same helper when determining the emitted element name:

```js id="hwmk00"
var tagname = serializedTagName(kid);
```

and `fallbackRawContentTags()` uses that identity for fallback ancestor detection:

```js id="t7m3gi"
const tagname = serializedTagName(node);

if (
  tagname &&
  hasRawContentFallback[tagname.toUpperCase()]
) {
  tags.push(tagname);
}
```

As a result, an ancestor that serializes with a fallback raw-content tag name is also recognized by the existing closing-tag protection.

For the same SVG `noembed` example, serialization becomes:

```html id="kn5lsv"
<noembed><?x &lt;/noembed ?><img src="x" onerror="alert(1)"></noembed>
```

The matching closing-tag prefix is escaped and therefore does not terminate the fallback raw-content context.

## Security impact

This keeps fallback raw-content ancestor detection consistent with the element identity used in serialized HTML.

Without this consistency, namespace or qualified-name representations can bypass the existing `ProcessingInstruction` ancestor-closing-tag protection while still producing the corresponding fallback tag name in the serialized response.

The demonstrated path is:

```text id="ybhgsa"
namespace / qualified-name fallback element
        ↓
ancestor check misses serialized fallback name
        ↓
ProcessingInstruction contains matching closing-tag prefix
        ↓
SSR serialization
        ↓
browser reparses the response as HTML
        ↓
fallback raw-content element closes early
        ↓
following sibling becomes active HTML
        ↓
JavaScript execution
```

This behavior was reproduced directly in Chromium against the Angular-pinned Domino revision.

## Relation to GHSA-j3r3-mxqp-r2p4

GHSA-j3r3-mxqp-r2p4 introduced escaping for matching fallback raw-content ancestor closing tags in `ProcessingInstruction` data.

That protection depends on `fallbackRawContentTags()` correctly identifying the relevant serialized ancestor.

This change does not alter the `ProcessingInstruction` escaping mechanism itself. Instead, it makes the ancestor identity used by that protection consistent with the identity used by element serialization.

The existing escaping mechanism is therefore reused once the serialized fallback ancestor is identified correctly.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

For normal element serialization, this only centralizes the existing tag-name selection into a shared helper and does not change which tag name is emitted.

The intentional behavior change is limited to recognizing additional serialized fallback ancestors in the existing security-sensitive escaping paths.

## Tests

A regression test was added for:

* SVG `noembed`;
* MathML `noembed`;
* SVG `iframe`;
* qualified-name HTML `iframe`.

The regression uses the executable sibling shape:

```js id="61151a"
const pi = document.createProcessingInstruction(
  'x',
  '</noembed ',
);

const img = document.createElement('img');
img.setAttribute('src', 'x');
img.setAttribute('onerror', 'alert(1)');
```

The regression was first verified against the unmodified Angular-pinned Domino revision:

```text id="xdpa18"
7df65450b8331278010e44eed0ef32225b07d203
```

Before this change, the regression fails because the matching fallback closing-tag prefix is not escaped.

With this change applied:

```text id="u1x4eo"
targeted regression: 1 passing
existing PI regression: 1 passing
XSS suite: 45 passing
full repository suite: 2179 passing
```

The following checks were run locally:

```bash id="91328o"
pnpm exec mocha test/xss.js \
  --grep "fallbackRawTextProcessingInstructionUsesSerializedAncestorName"

pnpm exec mocha test/xss.js \
  --grep "fallbackRawTextProcessingInstructionEscapesAncestorClosingTag"

pnpm exec mocha test/xss.js

pnpm test

git diff --check
```

## Other information

The browser portion was also validated directly in Chromium against the exact unmodified Angular-pinned Domino revision:

```text id="u6zvbe"
7df65450b8331278010e44eed0ef32225b07d203
```

Before this change, all tested representations resulted in JavaScript execution:

```text id="3cxe69"
SVG noembed             -> dialog=true
MathML noembed          -> dialog=true
SVG iframe              -> dialog=true
qualified-name iframe   -> dialog=true
```

For example, the unpatched SVG `noembed` case serialized as:

```html id="gj9yzo"
<noembed><?x </noembed ?><img
  src="x"
  onerror="alert('DOMINO_NAMESPACE_XSS:svg-noembed')"
></noembed>
```

and Chromium displayed the expected dialog.

With this PR applied, the same case serializes with the matching closing-tag prefix escaped:

```html id="lg0deg"
<noembed><?x &lt;/noembed ?><img
  src="x"
  onerror="alert('DOMINO_NAMESPACE_XSS:svg-noembed')"
></noembed>
```

and Chromium does not execute the sibling handler.

The same before/after behavior was verified for all four regression representations.

Fixes: https://github.com/angular/angular/issues/70652
More context : https://issuetracker.google.com/issues/556606385
